### PR TITLE
Add Hive view scene with hex grid and keyboard navigation

### DIFF
--- a/assets/tilesets/hex_tileset.tres
+++ b/assets/tilesets/hex_tileset.tres
@@ -1,0 +1,13 @@
+[gd_resource type="TileSet" load_steps=2 format=3]
+
+[ext_resource path="res://assets/sprites/hex_yellow.png" type="Texture2D" id=1]
+
+[resource]
+tile_size = Vector2i(64, 64)
+tile_shape = 3
+tile_offset_axis = 1
+sources/0 = SubResource("TileSetAtlasSource", 1)
+
+[sub_resource type="TileSetAtlasSource" id=1]
+texture = ExtResource(1)
+texture_region_size = Vector2i(64, 64)

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,15 @@
+; Engine configuration file.
+; It's best edited using the editor UI.
+; If you edit it manually, please keep the structure.
+
+config_version=5
+
+[application]
+config/name="BuzzyJess"
+run/main_scene="res://scenes/HiveView.tscn"
+
+[input]
+ui_right={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777233}]}
+ui_left={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777231}]}
+ui_down={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777234}]}
+ui_up={"deadzone":0.5,"events":[{"type":"InputEventKey","keycode":16777232}]}

--- a/scenes/HiveView.tscn
+++ b/scenes/HiveView.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource path="res://scripts/HiveView.gd" type="Script" id=1]
+[ext_resource path="res://scripts/Cursor.gd" type="Script" id=2]
+[ext_resource path="res://assets/tilesets/hex_tileset.tres" type="TileSet" id=3]
+
+[node name="HiveView" type="Node2D"]
+script = ExtResource(1)
+
+[node name="HexMap" type="TileMap" parent="."]
+tile_set = ExtResource(3)
+
+[node name="Cursor" type="Node2D" parent="."]
+script = ExtResource(2)
+
+[node name="Line2D" type="Line2D" parent="Cursor"]
+width = 3.0
+closed = true

--- a/scripts/Cursor.gd
+++ b/scripts/Cursor.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+@onready var line: Line2D = $Line2D
+
+func _ready() -> void:
+    var radius := 32.0 # half of 64
+    var h := sqrt(3.0) * 0.5 * radius
+    # Flat-top hex vertices (clockwise), centered at (0,0)
+    var pts := PackedVector2Array([
+        Vector2(+radius, 0),
+        Vector2(+radius * 0.5, +h),
+        Vector2(-radius * 0.5, +h),
+        Vector2(-radius, 0),
+        Vector2(-radius * 0.5, -h),
+        Vector2(+radius * 0.5, -h),
+    ])
+    line.points = pts
+    line.closed = true
+    line.width = 3.0
+    line.default_color = Color(1, 1, 1) # white

--- a/scripts/HiveView.gd
+++ b/scripts/HiveView.gd
@@ -1,0 +1,42 @@
+extends Node2D
+
+@onready var hex_map: TileMap = $HexMap
+@onready var cursor: Node2D = $Cursor
+var selected_cell: Vector2i = Vector2i(0, 0)
+
+func _ready() -> void:
+    _populate_demo_grid(12, 10) # q in [0..11], r in [0..9]
+    _update_cursor_position()
+
+func _populate_demo_grid(w:int, h:int) -> void:
+    # Assumes your TileSet has a source_id = 0 and tile_id = 0 for the yellow hex.
+    for q in w:
+        for r in h:
+            hex_map.set_cell(0, Vector2i(q, r), 0, Vector2i.ZERO)  # layer=0, source_id=0
+
+func _unhandled_input(event: InputEvent) -> void:
+    var delta := Vector2i.ZERO
+    if event.is_action_pressed("ui_right"):
+        delta = Vector2i(1, 0)
+    elif event.is_action_pressed("ui_left"):
+        delta = Vector2i(-1, 0)
+    elif event.is_action_pressed("ui_down"):
+        delta = Vector2i(0, 1)
+    elif event.is_action_pressed("ui_up"):
+        delta = Vector2i(0, -1)
+    if delta != Vector2i.ZERO:
+        _try_move_selection(delta)
+
+func _try_move_selection(delta: Vector2i) -> void:
+    var next := selected_cell + delta
+    # Check if a tile exists at next
+    if hex_map.get_cell_source_id(0, next) != -1:
+        selected_cell = next
+        _update_cursor_position()
+
+func _update_cursor_position() -> void:
+    # Center the Cursor on the target cell
+    var local_pos := hex_map.map_to_local(selected_cell)
+    # For hex TileMap, map_to_local returns the cell origin; center adjust by half tile
+    var center_offset := Vector2(hex_map.tile_set.tile_size.x * 0.5, hex_map.tile_set.tile_size.y * 0.5)
+    cursor.position = local_pos + center_offset


### PR DESCRIPTION
## Summary
- Add HiveView scene displaying a yellow hex TileMap and movable cursor
- Draw cursor outline with Line2D script
- Configure project input map for arrow-key movement
- Remove hex tile PNG asset; project expects `assets/sprites/hex_yellow.png`

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d54c87c83228a03e2f4b6afce85