### PR TITLE
Add build radial menu and controller

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,4 +13,6 @@ ui_right={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":41
 ui_left={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194319}]}
 ui_down={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194322}]}
 ui_up={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194320}]}
+confirm={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":32}]}
+cancel={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":90}]}
 

--- a/scenes/UI/BuildRadialMenu.tscn
+++ b/scenes/UI/BuildRadialMenu.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/ui/BuildRadialMenu.gd" type="Script" id=1]
+
+[node name="BuildRadialMenu" type="Control"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+script = ExtResource(1)
+
+[node name="Ring" type="Control" parent="BuildRadialMenu"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5

--- a/scripts/HiveView.gd
+++ b/scripts/HiveView.gd
@@ -3,10 +3,12 @@ extends Node2D
 @onready var hex_map: TileMap = $HexMap
 @onready var cursor: Node2D = $Cursor
 var selected_cell: Vector2i = Vector2i(0, 0)
+var build_menu: BuildRadialMenu
 
 func _ready() -> void:
     _populate_demo_grid(12, 10) # q in [0..11], r in [0..9]
     _update_cursor_position()
+    BuildController.tile_map = hex_map
 
 func _populate_demo_grid(w:int, h:int) -> void:
     # Assumes your TileSet has a source_id = 0 and tile_id = 0 for the yellow hex.
@@ -15,6 +17,8 @@ func _populate_demo_grid(w:int, h:int) -> void:
             hex_map.set_cell(0, Vector2i(q, r), 0, Vector2i.ZERO)  # layer=0, source_id=0
 
 func _unhandled_input(event: InputEvent) -> void:
+    if build_menu:
+        return
     var delta := Vector2i.ZERO
     if event.is_action_pressed("ui_right"):
         delta = Vector2i(1, 0)
@@ -24,6 +28,8 @@ func _unhandled_input(event: InputEvent) -> void:
         delta = Vector2i(0, 1)
     elif event.is_action_pressed("ui_up"):
         delta = Vector2i(0, -1)
+    elif event.is_action_pressed("confirm"):
+        _try_open_build_radial()
     if delta != Vector2i.ZERO:
         _try_move_selection(delta)
 
@@ -40,3 +46,25 @@ func _update_cursor_position() -> void:
     # For hex TileMap, map_to_local returns the cell origin; center adjust by half tile
     var center_offset := Vector2(hex_map.tile_set.tile_size.x * 0.5, hex_map.tile_set.tile_size.y * 0.5)
     cursor.position = local_pos + center_offset
+
+func _try_open_build_radial() -> void:
+    if build_menu:
+        return
+    var local_pos := hex_map.map_to_local(selected_cell)
+    var center_offset := Vector2(hex_map.tile_set.tile_size.x * 0.5, hex_map.tile_set.tile_size.y * 0.5)
+    var screen := hex_map.to_global(local_pos + center_offset)
+    var types := ["Brood","Storage","HoneyVat","WaxWorkshop","CandleHall","GuardPost","HerbalistDen"]
+    var opts := []
+    for t in types:
+        var cost := {"Comb":1}
+        var affordable := true
+        opts.append(BuildRadialMenu.BuildOption.new(t, t, null, cost, affordable))
+    var rm: BuildRadialMenu = preload("res://scenes/UI/BuildRadialMenu.tscn").instantiate()
+    get_tree().root.add_child(rm)
+    build_menu = rm
+    rm.open_at(screen, opts, 72, -90)
+    rm.option_chosen.connect(func(type:StringName):
+        BuildController.attempt_build(selected_cell, type)
+        build_menu = null)
+    rm.cancelled.connect(func():
+        build_menu = null)

--- a/scripts/controllers/BuildController.gd
+++ b/scripts/controllers/BuildController.gd
@@ -1,0 +1,16 @@
+extends Node
+class_name BuildController
+
+static var tile_map: TileMap
+static var built: Dictionary = {}
+
+static func is_cell_buildable(cell: Vector2i) -> bool:
+    return !built.has(cell)
+
+static func attempt_build(cell: Vector2i, type: StringName) -> bool:
+    if !is_cell_buildable(cell):
+        return false
+    built[cell] = type
+    if tile_map:
+        tile_map.set_cell(0, cell, 0, Vector2i.ZERO)
+    return true

--- a/scripts/ui/BuildRadialMenu.gd
+++ b/scripts/ui/BuildRadialMenu.gd
@@ -1,0 +1,136 @@
+extends Control
+class_name BuildRadialMenu
+
+signal option_chosen(type: StringName)
+signal cancelled
+
+class BuildOption:
+    var type: StringName
+    var label: String
+    var icon: Texture2D
+    var cost: Dictionary
+    var enabled: bool = true
+    func _init(t, l := "", i := null, c := {}, e := true):
+        type = t
+        label = l
+        icon = i
+        cost = c
+        enabled = e
+
+var _options: Array[BuildOption] = []
+var _selected := 0
+var _radius := 72.0
+var _start_angle_deg := -90.0
+var _is_open := false
+
+@onready var ring: Control = $Ring
+
+func open_at(pos_screen: Vector2, options: Array[BuildOption], radius := 72.0, start_angle_deg := -90.0) -> void:
+    _options = options
+    _radius = radius
+    _start_angle_deg = start_angle_deg
+    global_position = pos_screen
+    scale = Vector2.ZERO
+    _build_bubbles()
+    _animate_open()
+    _is_open = true
+    _selected = _default_index()
+    _update_highlight()
+
+func close_and_free(emit_cancel := false) -> void:
+    _animate_close(func():
+        if emit_cancel:
+            cancelled.emit()
+        queue_free())
+
+func _default_index() -> int:
+    for i in _options.size():
+        if _options[i].enabled:
+            return i
+    return 0
+
+func _build_bubbles() -> void:
+    for c in ring.get_children():
+        c.queue_free()
+    var positions := compute_positions(_options.size(), _radius, _start_angle_deg)
+    for i in _options.size():
+        var opt := _options[i]
+        var btn := Button.new()
+        btn.text = opt.label
+        btn.disabled = !opt.enabled
+        btn.position = Vector2.ZERO
+        btn.pivot_offset = btn.size * 0.5
+        ring.add_child(btn)
+        var tw := get_tree().create_tween()
+        tw.set_trans(Tween.TRANS_SINE)
+        tw.tween_property(btn, "position", positions[i], 0.2).from(Vector2.ZERO).set_delay(i * 0.02)
+        tw.parallel().tween_property(btn, "modulate:a", 1.0, 0.2).from(0.0).set_delay(i * 0.02)
+
+func compute_positions(n: int, r: float, start_deg: float) -> Array:
+    var pts: Array = []
+    if n <= 0:
+        return pts
+    for i in n:
+        var ang := deg_to_rad(start_deg + 360.0 / n * i)
+        pts.append(Vector2(cos(ang), sin(ang)) * r)
+    return pts
+
+func _unhandled_input(event: InputEvent) -> void:
+    if !_is_open:
+        return
+    var dir := Vector2.ZERO
+    if event.is_action_pressed("ui_right"):
+        dir = Vector2.RIGHT
+    elif event.is_action_pressed("ui_left"):
+        dir = Vector2.LEFT
+    elif event.is_action_pressed("ui_down"):
+        dir = Vector2.DOWN
+    elif event.is_action_pressed("ui_up"):
+        dir = Vector2.UP
+    if dir != Vector2.ZERO:
+        _select_closest(dir)
+        _update_highlight()
+        get_viewport().set_input_as_handled()
+        return
+    if event.is_action_pressed("confirm"):
+        var opt := _options[_selected]
+        if opt.enabled:
+            option_chosen.emit(opt.type)
+            close_and_free(false)
+        get_viewport().set_input_as_handled()
+    elif event.is_action_pressed("cancel"):
+        close_and_free(true)
+        get_viewport().set_input_as_handled()
+
+func _select_closest(dir: Vector2) -> void:
+    var best := _selected
+    var best_dot := -1.0
+    for i in _options.size():
+        var btn := ring.get_child(i)
+        var v := btn.position.normalized()
+        var d := dir.dot(v)
+        if d > best_dot:
+            best_dot = d
+            best = i
+    _selected = best
+
+func _update_highlight() -> void:
+    for i in ring.get_child_count():
+        var btn: Button = ring.get_child(i)
+        if i == _selected:
+            btn.scale = Vector2.ONE * 1.2
+        else:
+            btn.scale = Vector2.ONE
+        if btn.disabled:
+            btn.modulate = Color(0.6, 0.6, 0.6)
+        else:
+            btn.modulate = Color.WHITE
+
+func _animate_open() -> void:
+    var tw := create_tween()
+    tw.tween_property(self, "scale", Vector2.ONE, 0.2).from(Vector2.ZERO)
+
+func _animate_close(cb: Callable) -> void:
+    var tw := create_tween()
+    tw.tween_property(self, "scale", Vector2.ZERO, 0.15)
+    tw.finished.connect(cb)


### PR DESCRIPTION
## Summary
- add BuildRadialMenu scene and script with directional selection and confirm/cancel handling
- introduce BuildController helper to track simple built cells
- integrate radial build menu into HiveView and wire space/Z input actions

## Testing
- ⚠️ `godot4 --headless --check-only BuzzyJess/project.godot` (godot4 not installed)

------
https://chatgpt.com/codex/tasks/task_e_68c78b31b5cc832281f61f86910bee59