### PR TITLE
Handle viewport resize signal in HexGridTest

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -16,11 +16,13 @@ const SQRT_3 := sqrt(3.0)
 func _ready() -> void:
     _generate_grid()
     queue_redraw()
+    var viewport := get_viewport()
+    if viewport:
+        viewport.size_changed.connect(_on_viewport_size_changed)
 
-func _notification(what: int) -> void:
-    if what == NOTIFICATION_RESIZED:
-        _update_offset()
-        queue_redraw()
+func _on_viewport_size_changed() -> void:
+    _update_offset()
+    queue_redraw()
 
 func _generate_grid() -> void:
     _hex_coords.clear()


### PR DESCRIPTION
## Summary
- connect the hex grid test node to the viewport size_changed signal
- recompute the grid offset when the viewport resizes instead of relying on Control notifications

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca9c915854832289765b163fb03d01