### PR TITLE
Fix radial build menu script errors

### DIFF
--- a/data/configs/cells.json
+++ b/data/configs/cells.json
@@ -1,0 +1,31 @@
+{
+  "Brood": {
+    "cost": {"Comb": 10, "Honey": 1},
+    "reverts_to": "Empty",
+    "mergeable": false
+  },
+  "Storage": {
+    "cost": {"Comb": 8},
+    "mergeable": true
+  },
+  "HoneyVat": {
+    "cost": {"Comb": 6, "NectarCommon": 4},
+    "mergeable": true
+  },
+  "WaxWorkshop": {
+    "cost": {"Pollen": 5, "NectarCommon": 3},
+    "mergeable": true
+  },
+  "CandleHall": {
+    "cost": {"Comb": 4, "Honey": 4, "Pollen": 4},
+    "mergeable": true
+  },
+  "GuardPost": {
+    "cost": {"Comb": 5, "Honey": 3, "PetalRed": 2},
+    "mergeable": true
+  },
+  "HerbalistDen": {
+    "cost": {"Comb": 3, "Honey": 3, "Pollen": 6},
+    "mergeable": true
+  }
+}

--- a/project.godot
+++ b/project.godot
@@ -8,6 +8,11 @@ config_version=5
 config/name="BuzzyJess"
 run/main_scene="res://scenes/TestHex.tscn"
 
+[autoload]
+ConfigDB="*res://scripts/autoload/ConfigDB.gd"
+GameState="*res://scripts/autoload/GameState.gd"
+Events="*res://scripts/autoload/Events.gd"
+
 [input]
 ui_right={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194321}]}
 ui_left={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194319}]}

--- a/scenes/TestHex.tscn
+++ b/scenes/TestHex.tscn
@@ -1,6 +1,18 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scripts/HexGridTest.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/controllers/BuildController.gd" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/UI/BuildRadialMenu.tscn" id="3"]
 
 [node name="TestHex" type="Node2D"]
 script = ExtResource("1")
+
+[node name="BuildController" type="Node" parent="."]
+script = ExtResource("2")
+build_menu_path = NodePath("../CanvasLayer/BuildRadialMenu")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+layer = 1
+
+[node name="BuildRadialMenu" parent="CanvasLayer" instance=ExtResource("3")]
+visible = false

--- a/scenes/UI/BuildRadialMenu.tscn
+++ b/scenes/UI/BuildRadialMenu.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/BuildRadialMenu.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/SelectionRing.gd" id="2"]
+
+[node name="BuildRadialMenu" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+mouse_filter = 2
+script = ExtResource("1")
+
+[node name="OptionLayer" type="Control" parent="."]
+mouse_filter = 2
+
+[node name="SelectionRing" type="Control" parent="OptionLayer"]
+offset_right = 72.0
+offset_bottom = 72.0
+mouse_filter = 2
+script = ExtResource("2")

--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+const HiveSystem := preload("res://scripts/systems/HiveSystem.gd")
+
 @export var hex_size: float = 48.0
 @export var grid_radius: int = 3
 @export var hex_color: Color = Color(1.0, 0.9, 0.1)
@@ -8,13 +10,31 @@ extends Node2D
 
 var _hex_coords: Array[Vector2i] = []
 var _positions: Dictionary = {}
+var _cell_ids_by_coord: Dictionary = {}
+var _coords_by_id: Dictionary = {}
 var _selection: Vector2i = Vector2i.ZERO
 var _grid_offset: Vector2 = Vector2.ZERO
 
 const SQRT_3 := sqrt(3.0)
 
+var _cell_type_colors := {
+    "Empty": Color(1.0, 0.9, 0.1),
+    "Brood": Color(0.8, 0.4, 0.4),
+    "Storage": Color(0.7, 0.7, 0.2),
+    "HoneyVat": Color(0.9, 0.7, 0.3),
+    "WaxWorkshop": Color(0.7, 0.5, 0.3),
+    "CandleHall": Color(0.6, 0.5, 0.9),
+    "GuardPost": Color(0.4, 0.6, 0.8),
+    "HerbalistDen": Color(0.5, 0.8, 0.5)
+}
+
+@onready var _build_controller: BuildController = $BuildController
+@onready var _build_menu: BuildRadialMenu = $CanvasLayer/BuildRadialMenu
+
 func _ready() -> void:
     _generate_grid()
+    if Events.cell_built.is_connected(_on_cell_built) == false:
+        Events.cell_built.connect(_on_cell_built)
     queue_redraw()
     var viewport := get_viewport()
     if viewport:
@@ -27,6 +47,11 @@ func _on_viewport_size_changed() -> void:
 func _generate_grid() -> void:
     _hex_coords.clear()
     _positions.clear()
+    _cell_ids_by_coord.clear()
+    _coords_by_id.clear()
+    HiveSystem.reset()
+
+    var cell_id := 0
 
     for q in range(-grid_radius, grid_radius + 1):
         for r in range(-grid_radius, grid_radius + 1):
@@ -36,6 +61,13 @@ func _generate_grid() -> void:
                 _hex_coords.append(coord)
                 var pos := _axial_to_pixel(coord)
                 _positions[coord] = pos
+                _cell_ids_by_coord[coord] = cell_id
+                _coords_by_id[cell_id] = coord
+                HiveSystem.register_cell(cell_id, {
+                    "coord": coord,
+                    "type": "Empty"
+                })
+                cell_id += 1
     _update_offset()
 
 func _update_offset() -> void:
@@ -58,34 +90,47 @@ func _update_offset() -> void:
     _grid_offset = get_viewport_rect().size * 0.5 - grid_center
 
 func _unhandled_input(event: InputEvent) -> void:
+    if _build_menu and _build_menu.is_open():
+        return
+
     if event.is_action_pressed("ui_right"):
-        print("Input action: ui_right")
         _try_move_selection(Vector2i(1, 0))
     elif event.is_action_pressed("ui_left"):
-        print("Input action: ui_left")
         _try_move_selection(Vector2i(-1, 0))
     elif event.is_action_pressed("ui_up"):
-        print("Input action: ui_up")
         _try_move_selection(Vector2i(0, -1))
     elif event.is_action_pressed("ui_down"):
-        print("Input action: ui_down")
         _try_move_selection(Vector2i(0, 1))
+    elif event.is_action_pressed("confirm"):
+        _handle_confirm()
 
 func _try_move_selection(delta: Vector2i) -> void:
     var next_coord := _selection + delta
-    print("Trying to move selection from", _selection, "by", delta, "->", next_coord)
     if _positions.has(next_coord):
         _selection = next_coord
-        print("Selection moved to", _selection)
         queue_redraw()
-    else:
-        print("No hex at", next_coord)
+
+func _handle_confirm() -> void:
+    var cell_id := _cell_ids_by_coord.get(_selection, -1)
+    if cell_id == -1:
+        return
+    if HiveSystem.get_cell_type(cell_id) != "Empty":
+        return
+    if _build_controller:
+        var world_position := _get_cell_center(_selection)
+        _build_controller.open_radial(cell_id, world_position)
+
+func _get_cell_center(coord: Vector2i) -> Vector2:
+    return _positions.get(coord, Vector2.ZERO) + _grid_offset
 
 func _draw() -> void:
     for coord in _hex_coords:
         var center: Vector2 = _positions.get(coord, Vector2.ZERO) + _grid_offset
         var points := _hex_points(center)
-        draw_colored_polygon(points, hex_color)
+        var cell_id := _cell_ids_by_coord.get(coord, -1)
+        var cell_type := HiveSystem.get_cell_type(cell_id) if cell_id != -1 else "Empty"
+        var fill_color := _cell_type_colors.get(cell_type, hex_color)
+        draw_colored_polygon(points, fill_color)
         if coord == _selection:
             var outline_points := points.duplicate()
             outline_points.append(outline_points[0])
@@ -105,3 +150,6 @@ func _hex_points(center: Vector2) -> PackedVector2Array:
         var point := center + Vector2(cos(angle), sin(angle)) * hex_size
         points.append(point)
     return points
+
+func _on_cell_built(cell_id: int, cell_type: StringName) -> void:
+    queue_redraw()

--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -1,0 +1,59 @@
+extends Node
+
+const BUILD_ORDER: Array[StringName] = [
+    StringName("Brood"),
+    StringName("Storage"),
+    StringName("HoneyVat"),
+    StringName("WaxWorkshop"),
+    StringName("CandleHall"),
+    StringName("GuardPost"),
+    StringName("HerbalistDen")
+]
+
+var _cell_defs: Dictionary = {}
+var _buildable_ids: Array[StringName] = []
+
+func _ready() -> void:
+    load_cells()
+
+func load_cells() -> void:
+    _cell_defs.clear()
+    _buildable_ids.clear()
+    var path: String = "res://data/configs/cells.json"
+    if not FileAccess.file_exists(path):
+        push_warning("cells.json not found at %s" % path)
+        return
+    var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+    if file == null:
+        push_warning("Failed to open %s" % path)
+        return
+    var text: String = file.get_as_text()
+    file.close()
+    var parsed: Variant = JSON.parse_string(text)
+    if typeof(parsed) != TYPE_DICTIONARY:
+        push_warning("Invalid cells.json contents")
+        return
+    _cell_defs = parsed
+    for id in BUILD_ORDER:
+        if _cell_defs.has(String(id)):
+            _buildable_ids.append(id)
+    for key in _cell_defs.keys():
+        if key == "Empty":
+            continue
+        var id: StringName = StringName(key)
+        if _buildable_ids.has(id):
+            continue
+        _buildable_ids.append(id)
+
+func get_buildable_cell_types() -> Array[StringName]:
+    return _buildable_ids.duplicate()
+
+func get_cell_cost(cell_type: StringName) -> Dictionary:
+    var def: Dictionary = _cell_defs.get(String(cell_type), {})
+    var cost: Variant = def.get("cost", {})
+    if typeof(cost) == TYPE_DICTIONARY:
+        return cost.duplicate(true)
+    return {}
+
+func has_cell_type(cell_type: StringName) -> bool:
+    return _cell_defs.has(String(cell_type))

--- a/scripts/autoload/Events.gd
+++ b/scripts/autoload/Events.gd
@@ -1,0 +1,7 @@
+extends Node
+
+signal cell_built(cell_id: int, cell_type: StringName)
+signal resources_changed(snapshot: Dictionary)
+signal build_menu_opened(cell_id: int)
+signal build_menu_closed()
+signal build_failed(cell_id: int)

--- a/scripts/autoload/GameState.gd
+++ b/scripts/autoload/GameState.gd
@@ -1,0 +1,26 @@
+extends Node
+
+var resources: Dictionary = {
+    "Comb": 40,
+    "Honey": 30,
+    "Pollen": 30,
+    "NectarCommon": 25,
+    "PetalRed": 10
+}
+
+func can_afford(cost: Dictionary) -> bool:
+    for key in cost.keys():
+        var amount: float = cost[key]
+        if resources.get(key, 0) < amount:
+            return false
+    return true
+
+func spend(cost: Dictionary) -> bool:
+    if not can_afford(cost):
+        return false
+    for key in cost.keys():
+        resources[key] = resources.get(key, 0) - cost[key]
+    return true
+
+func get_resources_snapshot() -> Dictionary:
+    return resources.duplicate(true)

--- a/scripts/controllers/BuildController.gd
+++ b/scripts/controllers/BuildController.gd
@@ -1,0 +1,33 @@
+extends Node
+class_name BuildController
+
+@export var build_menu_path: NodePath
+
+var build_menu: BuildRadialMenu
+var current_cell_id: int = -1
+
+func _ready() -> void:
+    if build_menu_path != NodePath():
+        build_menu = get_node_or_null(build_menu_path)
+    if build_menu:
+        build_menu.menu_closed.connect(_on_menu_closed)
+        build_menu.build_chosen.connect(_on_build_chosen)
+
+func is_menu_open() -> bool:
+    return build_menu != null and build_menu.is_open()
+
+func open_radial(cell_id: int, world_position: Vector2) -> void:
+    current_cell_id = cell_id
+    if build_menu:
+        build_menu.open_for_cell(cell_id, world_position)
+
+func close_menu() -> void:
+    if build_menu and build_menu.is_open():
+        build_menu.close()
+
+func _on_menu_closed() -> void:
+    current_cell_id = -1
+
+func _on_build_chosen(cell_type: StringName) -> void:
+    # Placeholder hook for future build effects.
+    pass

--- a/scripts/systems/HiveSystem.gd
+++ b/scripts/systems/HiveSystem.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name HiveSystem
+
+static var _cells: Dictionary = {}
+
+static func reset() -> void:
+    _cells.clear()
+
+static func register_cell(cell_id: int, data: Dictionary) -> void:
+    _cells[cell_id] = data.duplicate(true)
+
+static func convert_cell_type(cell_id: int, new_type: StringName) -> void:
+    if not _cells.has(cell_id):
+        return
+    _cells[cell_id]["type"] = String(new_type)
+
+static func get_cell_type(cell_id: int) -> String:
+    return _cells.get(cell_id, {}).get("type", "Empty")
+
+static func get_cells() -> Dictionary:
+    return _cells.duplicate(true)

--- a/scripts/systems/MergeSystem.gd
+++ b/scripts/systems/MergeSystem.gd
@@ -1,0 +1,6 @@
+extends Node
+class_name MergeSystem
+
+static func recompute_for(cell_id: int) -> void:
+    # Placeholder for merge logic; keeping stub for integration.
+    pass

--- a/scripts/ui/BuildRadialMenu.gd
+++ b/scripts/ui/BuildRadialMenu.gd
@@ -1,0 +1,290 @@
+extends Control
+class_name BuildRadialMenu
+
+signal build_chosen(cell_type: StringName)
+signal menu_closed()
+
+const HiveSystem := preload("res://scripts/systems/HiveSystem.gd")
+const MergeSystem := preload("res://scripts/systems/MergeSystem.gd")
+
+@export var radius: float = 96.0
+@export var button_size: Vector2 = Vector2(48, 48)
+@export var animation_duration: float = 0.12
+@export var padding: Vector2 = Vector2(120, 140)
+
+var cell_id: int = -1
+var center: Vector2 = Vector2.ZERO
+var options: Array[StringName] = []
+var angles: Array[float] = []
+var buttons: Array[RadialOptionControl] = []
+var costs: Array[Dictionary] = []
+var affordable: Array[bool] = []
+var selected_index: int = -1
+
+var _is_open: bool = false
+var _open_tween: Tween = null
+var _close_tween: Tween = null
+
+@onready var option_layer: Control = $OptionLayer
+@onready var selection_ring: Control = $OptionLayer/SelectionRing
+
+class RadialOptionControl extends Control:
+    var label_text: String = ""
+    var cost_text: String = ""
+    var affordable: bool = true
+    var icon_size: Vector2 = Vector2.ZERO
+    var base_color: Color = Color(0.89, 0.7, 0.21)
+    var disabled_alpha: float = 0.5
+    var _flash_tween: Tween = null
+
+    func setup(label: StringName, cost: Dictionary, size: Vector2, is_affordable: bool) -> void:
+        label_text = String(label)
+        icon_size = size
+        affordable = is_affordable
+        cost_text = _format_cost(cost)
+        mouse_filter = Control.MOUSE_FILTER_IGNORE
+        custom_minimum_size = Vector2(size.x, size.y + 36)
+        size = custom_minimum_size
+        queue_redraw()
+
+    func _format_cost(cost: Dictionary) -> String:
+        if cost.is_empty():
+            return "Free"
+        var keys: Array = cost.keys()
+        keys.sort()
+        var parts: Array[String] = []
+        for key in keys:
+            parts.append("%s %s" % [str(cost[key]), key])
+        return " / ".join(parts)
+
+    func flash_unaffordable() -> void:
+        if _flash_tween:
+            _flash_tween.kill()
+        modulate = Color.WHITE
+        _flash_tween = create_tween()
+        _flash_tween.tween_property(self, "modulate", Color(1.0, 0.4, 0.4), 0.05)
+        _flash_tween.tween_property(self, "modulate", Color.WHITE, 0.12)
+
+    func _draw() -> void:
+        var icon_center: Vector2 = Vector2(icon_size.x * 0.5, icon_size.y * 0.5)
+        var icon_radius: float = min(icon_size.x, icon_size.y) * 0.5
+        var color: Color = base_color
+        if not affordable:
+            color.a = disabled_alpha
+        draw_circle(icon_center, icon_radius, color)
+        var font: Font = get_theme_default_font()
+        if font:
+            var width: float = max(size.x, icon_size.x)
+            var label_size: Vector2 = font.get_string_size(label_text)
+            var label_pos: Vector2 = Vector2((width - label_size.x) * 0.5, icon_size.y + 16)
+            draw_string(font, label_pos, label_text)
+            var cost_color: Color = Color(0.4, 0.9, 0.4) if affordable else Color(0.9, 0.3, 0.3)
+            var cost_size: Vector2 = font.get_string_size(cost_text)
+            var cost_pos: Vector2 = Vector2((width - cost_size.x) * 0.5, icon_size.y + 32)
+            draw_string(font, cost_pos, cost_text, HORIZONTAL_ALIGNMENT_LEFT, -1, -1, cost_color)
+
+func _ready() -> void:
+    visible = false
+    mouse_filter = Control.MOUSE_FILTER_IGNORE
+    option_layer.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    selection_ring.visible = false
+    selection_ring.pivot_offset = selection_ring.size * 0.5
+    set_process_unhandled_input(true)
+
+func is_open() -> bool:
+    return _is_open
+
+func open_for_cell(p_cell_id: int, world_pos: Vector2) -> void:
+    cell_id = p_cell_id
+    center = _to_canvas_position(world_pos)
+    _clamp_center()
+    _prepare_options()
+    option_layer.global_position = center
+    option_layer.position = center
+    _layout_buttons()
+    Events.build_menu_opened.emit(cell_id)
+    _is_open = true
+    visible = true
+    option_layer.scale = Vector2(0.8, 0.8)
+    option_layer.modulate = Color(1, 1, 1, 0)
+    if options.size() > 0:
+        selection_ring.visible = true
+        selection_ring.modulate = Color(1, 1, 1, 1)
+    _animate_in()
+
+func close() -> void:
+    if not _is_open:
+        return
+    _animate_out()
+
+func _prepare_options() -> void:
+    options.clear()
+    angles.clear()
+    buttons.clear()
+    costs.clear()
+    affordable.clear()
+    for child: Node in option_layer.get_children():
+        if child == selection_ring:
+            continue
+        child.queue_free()
+    var buildable: Array[StringName] = ConfigDB.get_buildable_cell_types()
+    for cell_type: StringName in buildable:
+        options.append(cell_type)
+    var count: int = options.size()
+    if count == 0:
+        selected_index = -1
+        _show_empty_placeholder()
+        return
+    var start_angle: float = -PI * 0.5
+    for i: int in count:
+        var angle: float = start_angle + float(i) * TAU / float(count)
+        angles.append(angle)
+        var cost: Dictionary = ConfigDB.get_cell_cost(options[i])
+        costs.append(cost)
+        affordable.append(GameState.can_afford(cost))
+    selected_index = clamp(selected_index, 0, count - 1)
+    if selected_index < 0:
+        selected_index = 0
+
+func _show_empty_placeholder() -> void:
+    selection_ring.visible = false
+    var label: Label = Label.new()
+    label.text = "No build options"
+    label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    label.custom_minimum_size = Vector2(200, 40)
+    label.position = -label.custom_minimum_size * 0.5
+    option_layer.add_child(label)
+
+func _layout_buttons() -> void:
+    if options.is_empty():
+        return
+    buttons.clear()
+    for i: int in options.size():
+        var btn: RadialOptionControl = RadialOptionControl.new()
+        var cost: Dictionary = costs[i]
+        var can_build: bool = affordable[i]
+        btn.setup(options[i], cost, button_size, can_build)
+        var offset: Vector2 = Vector2(radius, 0).rotated(angles[i]) - button_size * 0.5
+        btn.position = offset
+        option_layer.add_child(btn)
+        buttons.append(btn)
+    selected_index = clamp(selected_index, 0, options.size() - 1)
+    _update_ring()
+
+func _unhandled_input(event: InputEvent) -> void:
+    if not _is_open:
+        return
+    if event.is_action_pressed("ui_right"):
+        _select_dir(Vector2.RIGHT)
+        accept_event()
+    elif event.is_action_pressed("ui_left"):
+        _select_dir(Vector2.LEFT)
+        accept_event()
+    elif event.is_action_pressed("ui_up"):
+        _select_dir(Vector2.UP)
+        accept_event()
+    elif event.is_action_pressed("ui_down"):
+        _select_dir(Vector2.DOWN)
+        accept_event()
+    elif event.is_action_pressed("confirm"):
+        _confirm()
+        accept_event()
+    elif event.is_action_pressed("cancel"):
+        close()
+        accept_event()
+
+func _select_dir(dir: Vector2) -> void:
+    if options.is_empty():
+        return
+    var best_dot: float = -INF
+    var idx: int = selected_index
+    for i: int in options.size():
+        var v: Vector2 = Vector2.RIGHT.rotated(angles[i])
+        var d: float = v.normalized().dot(dir)
+        if d > best_dot:
+            best_dot = d
+            idx = i
+    if idx != selected_index:
+        selected_index = idx
+        _update_ring()
+
+func _update_ring() -> void:
+    if options.is_empty() or selected_index < 0 or selected_index >= angles.size():
+        selection_ring.visible = false
+        return
+    var local_center: Vector2 = Vector2(radius, 0).rotated(angles[selected_index])
+    selection_ring.visible = true
+    selection_ring.scale = Vector2.ONE
+    selection_ring.global_position = option_layer.global_position + local_center - selection_ring.pivot_offset
+    selection_ring.queue_redraw()
+
+func _confirm() -> void:
+    if options.is_empty():
+        close()
+        return
+    if selected_index < 0 or selected_index >= options.size():
+        return
+    if HiveSystem.get_cell_type(cell_id) != "Empty":
+        Events.build_failed.emit(cell_id)
+        close()
+        return
+    var cell_type: StringName = options[selected_index]
+    var cost: Dictionary = costs[selected_index]
+    if not GameState.can_afford(cost) or not GameState.spend(cost):
+        _show_unaffordable_feedback(selected_index)
+        return
+    HiveSystem.convert_cell_type(cell_id, cell_type)
+    MergeSystem.recompute_for(cell_id)
+    Events.cell_built.emit(cell_id, cell_type)
+    Events.resources_changed.emit(GameState.get_resources_snapshot())
+    build_chosen.emit(cell_type)
+    close()
+
+func _show_unaffordable_feedback(idx: int) -> void:
+    if idx >= 0 and idx < buttons.size():
+        buttons[idx].flash_unaffordable()
+    var tween: Tween = create_tween()
+    tween.tween_property(selection_ring, "scale", selection_ring.scale * 1.15, 0.08).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+    tween.tween_property(selection_ring, "scale", Vector2.ONE, 0.12).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_IN)
+
+func _animate_in() -> void:
+    if _open_tween:
+        _open_tween.kill()
+    if _close_tween:
+        _close_tween.kill()
+    _open_tween = create_tween()
+    _open_tween.tween_property(option_layer, "scale", Vector2.ONE, animation_duration).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+    _open_tween.parallel().tween_property(option_layer, "modulate:a", 1.0, animation_duration)
+
+func _animate_out() -> void:
+    if _close_tween:
+        _close_tween.kill()
+    if _open_tween:
+        _open_tween.kill()
+    _close_tween = create_tween()
+    _close_tween.tween_property(option_layer, "scale", Vector2(0.8, 0.8), animation_duration).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_IN)
+    _close_tween.parallel().tween_property(option_layer, "modulate:a", 0.0, animation_duration)
+    _close_tween.finished.connect(_on_close_finished)
+
+func _on_close_finished() -> void:
+    _is_open = false
+    visible = false
+    selection_ring.visible = false
+    Events.build_menu_closed.emit()
+    menu_closed.emit()
+
+func _to_canvas_position(world_pos: Vector2) -> Vector2:
+    var viewport: Viewport = get_viewport()
+    if viewport:
+        var camera: Camera2D = viewport.get_camera_2d()
+        if camera:
+            return camera.unproject_position(world_pos)
+    return world_pos
+
+func _clamp_center() -> void:
+    var rect: Rect2i = get_viewport_rect()
+    var margin_x: float = max(padding.x, radius + button_size.x)
+    var margin_y: float = max(padding.y, radius + button_size.y + 48.0)
+    center.x = clamp(center.x, margin_x, rect.size.x - margin_x)
+    center.y = clamp(center.y, margin_y, rect.size.y - margin_y)

--- a/scripts/ui/SelectionRing.gd
+++ b/scripts/ui/SelectionRing.gd
@@ -1,0 +1,34 @@
+extends Control
+
+@export var ring_color: Color = Color.WHITE
+@export var ring_width: float = 3.0
+@export var pulse_scale: float = 0.05
+@export var pulse_duration: float = 0.6
+
+var _pulse_tween: Tween
+
+func _ready() -> void:
+    mouse_filter = Control.MOUSE_FILTER_IGNORE
+    pivot_offset = size * 0.5
+    _start_pulse()
+    queue_redraw()
+
+func _start_pulse() -> void:
+    if _pulse_tween:
+        _pulse_tween.kill()
+    scale = Vector2.ONE
+    _pulse_tween = create_tween()
+    _pulse_tween.set_loops()
+    _pulse_tween.tween_property(self, "scale", Vector2.ONE * (1.0 + pulse_scale), pulse_duration * 0.5).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+    _pulse_tween.tween_property(self, "scale", Vector2.ONE, pulse_duration * 0.5).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
+
+func stop_pulse() -> void:
+    if _pulse_tween:
+        _pulse_tween.kill()
+        _pulse_tween = null
+    scale = Vector2.ONE
+    queue_redraw()
+
+func _draw() -> void:
+    var radius := min(size.x, size.y) * 0.5 - ring_width * 0.5
+    draw_arc(pivot_offset, radius, 0.0, TAU, 96, ring_color, ring_width)


### PR DESCRIPTION
## Summary
- update the radial build menu script to use valid Godot ternary syntax and explicit typing so it parses correctly
- remove conflicting `class_name` declarations from autoload singletons and strengthen their typed values to satisfy warnings
- ensure radial menu option loops declare typed iteration variables so Variant inference warnings no longer trigger

## Testing
- ⚠️ `godot4 --headless --quit` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd41382cc8322a5f4e1c547220b3f