### PR TITLE
Fix radius type inference in SelectionRing

### DIFF
--- a/scripts/ui/SelectionRing.gd
+++ b/scripts/ui/SelectionRing.gd
@@ -30,5 +30,5 @@ func stop_pulse() -> void:
     queue_redraw()
 
 func _draw() -> void:
-    var radius := min(size.x, size.y) * 0.5 - ring_width * 0.5
+    var radius: float = min(size.x, size.y) * 0.5 - ring_width * 0.5
     draw_arc(pivot_offset, radius, 0.0, TAU, 96, ring_color, ring_width)


### PR DESCRIPTION
## Summary
- ensure SelectionRing radius calculation uses an explicitly typed float to satisfy static typing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6d6603b88322baaec7e19db4aaa3