### PR TITLE
Fix parse errors caused by leftover patch markers

### DIFF
--- a/scripts/controllers/AssignController.gd
+++ b/scripts/controllers/AssignController.gd
@@ -56,4 +56,3 @@ func _on_assign_confirmed(cell_id: int, group_id: int, bee_id: int) -> void:
 
 func _on_panel_closed() -> void:
     _current_cell = -1
-*** End Patch

--- a/scripts/systems/HiveSystem.gd
+++ b/scripts/systems/HiveSystem.gd
@@ -119,4 +119,3 @@ static func _clear_assignments(entry: Dictionary) -> void:
             if bee_id != -1:
                 GameState.unassign_bee(bee_id)
     entry["assigned"] = []
-*** End Patch

--- a/scripts/ui/AssignBeePanel.gd
+++ b/scripts/ui/AssignBeePanel.gd
@@ -193,4 +193,3 @@ func _on_animation_finished(anim_name: StringName) -> void:
         panel_closed.emit()
     elif anim_name == StringName("slide_in"):
         position.x = 0
-*** End Patch


### PR DESCRIPTION
## Summary
- remove stray `*** End Patch` markers that broke parsing of HiveSystem, AssignController, and AssignBeePanel scripts

## Testing
- not run (Godot binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc8a7dbfc88322911f3cc105c2517d