### PR TITLE
Use StyleBoxFlat border width setter

### DIFF
--- a/scripts/ui/AssignBeePanel.gd
+++ b/scripts/ui/AssignBeePanel.gd
@@ -51,7 +51,7 @@ func _apply_panel_style() -> void:
     var style := StyleBoxFlat.new()
     style.bg_color = Color(0.11, 0.1, 0.12, 0.92)
     style.border_color = Color(1.0, 0.77, 0.34)
-    style.border_width_all = 2
+    style.set_border_width_all(2)
     style.corner_radius_all = 18
     panel.add_theme_stylebox_override("panel", style)
 
@@ -77,7 +77,7 @@ func _make_row(bee: Dictionary, eff: int, selected: bool) -> Control:
     var style := StyleBoxFlat.new()
     style.bg_color = Color(0.22, 0.2, 0.25, 0.9)
     style.corner_radius_all = 14
-    style.border_width_all = 2 if selected else 1
+    style.set_border_width_all(2 if selected else 1)
     style.border_color = Color(1.0, 0.74, 0.32) if selected else Color(0.45, 0.45, 0.52)
     container.add_theme_stylebox_override("panel", style)
     container.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -118,7 +118,7 @@ func _make_badge(efficiency: int) -> Control:
     var style := StyleBoxFlat.new()
     style.bg_color = Color(0.28, 0.45, 0.28, 0.9) if efficiency >= 0 else Color(0.6, 0.28, 0.28, 0.9)
     style.corner_radius_all = 12
-    style.border_width_all = 1
+    style.set_border_width_all(1)
     style.border_color = Color(1, 1, 1, 0.6)
     badge.add_theme_stylebox_override("panel", style)
 


### PR DESCRIPTION
## Summary
- call `set_border_width_all` instead of assigning to `border_width_all` when configuring StyleBoxFlat instances

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc8b6f80b88322b9381d3f3bb4da1e