### PR TITLE
Add resources panel UI and resource data support

### DIFF
--- a/data/configs/resources.json
+++ b/data/configs/resources.json
@@ -1,0 +1,9 @@
+{
+  "resources": [
+    {"id": "Honey", "display_name": "Honey", "cap": 50, "initial": 30},
+    {"id": "Comb", "display_name": "Comb", "cap": 80, "initial": 40},
+    {"id": "Pollen", "display_name": "Pollen", "cap": 60, "initial": 30},
+    {"id": "NectarCommon", "display_name": "Common Nectar", "cap": 40, "initial": 25},
+    {"id": "PetalRed", "display_name": "Red Petals", "cap": 25, "initial": 10}
+  ]
+}

--- a/project.godot
+++ b/project.godot
@@ -12,6 +12,7 @@ run/main_scene="res://scenes/TestHex.tscn"
 ConfigDB="*res://scripts/autoload/ConfigDB.gd"
 GameState="*res://scripts/autoload/GameState.gd"
 Events="*res://scripts/autoload/Events.gd"
+IconDB="*res://scripts/autoload/IconDB.gd"
 
 [input]
 ui_right={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194321}]}
@@ -20,4 +21,5 @@ ui_down={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":419
 ui_up={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194320}]}
 confirm={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":32}]}
 cancel={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":90}]}
+resources_panel_toggle={"deadzone":0.5,"events":[{"type":"InputEventKey","physical_keycode":4194305},{"type":"InputEventJoypadButton","button_index":7}]}
 

--- a/scenes/TestHex.tscn
+++ b/scenes/TestHex.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3]
+[gd_scene load_steps=7 format=3]
 
 [ext_resource type="Script" path="res://scripts/HexGridTest.gd" id="1"]
 [ext_resource type="Script" path="res://scripts/controllers/BuildController.gd" id="2"]
 [ext_resource type="PackedScene" path="res://scenes/UI/BuildRadialMenu.tscn" id="3"]
 [ext_resource type="Script" path="res://scripts/controllers/AssignController.gd" id="4"]
 [ext_resource type="PackedScene" path="res://scenes/UI/AssignBeePanel.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://scenes/UI/ResourcesPanel.tscn" id="6"]
 
 [node name="TestHex" type="Node2D"]
 script = ExtResource("1")
@@ -24,4 +25,7 @@ layer = 1
 visible = false
 
 [node name="AssignBeePanel" parent="CanvasLayer" instance=ExtResource("5")]
+visible = false
+
+[node name="ResourcesPanel" parent="CanvasLayer" instance=ExtResource("6")]
 visible = false

--- a/scenes/UI/ResourceRow.tscn
+++ b/scenes/UI/ResourceRow.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/ResourceRow.gd" id="1"]
+
+[node name="ResourceRow" type="PanelContainer"]
+custom_minimum_size = Vector2(0, 72)
+size_flags_horizontal = 3
+script = ExtResource("1")
+
+[node name="HBox" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/separation = 16
+alignment = 1
+
+[node name="Icon" type="TextureRect" parent="HBox"]
+custom_minimum_size = Vector2(48, 48)
+stretch_mode = 4
+
+[node name="Info" type="VBoxContainer" parent="HBox"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/separation = 6
+
+[node name="Name" type="Label" parent="HBox/Info"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Resource"
+vertical_alignment = 1
+
+[node name="Bar" type="Control" parent="HBox/Info"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+custom_minimum_size = Vector2(0, 12)
+
+[node name="Bg" type="ColorRect" parent="HBox/Info/Bar"]
+layout_mode = 1
+anchors_preset = 15
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+color = Color(0.07, 0.07, 0.09, 0.8)
+
+[node name="Fg" type="ColorRect" parent="HBox/Info/Bar"]
+layout_mode = 1
+anchor_right = 0.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_vertical = 3
+color = Color(1, 0.72, 0.28, 0.9)
+
+[node name="Qty" type="Label" parent="HBox"]
+size_flags_vertical = 3
+text = "0/0"
+vertical_alignment = 1
+horizontal_alignment = 2
+custom_minimum_size = Vector2(80, 0)

--- a/scenes/UI/ResourcesPanel.tscn
+++ b/scenes/UI/ResourcesPanel.tscn
@@ -1,0 +1,117 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/ResourcesPanel.gd" id="1"]
+
+[sub_resource type="Animation" id="1"]
+resource_name = "slide_in"
+length = 0.18
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position:x")
+tracks/0/interp = 1
+tracks/0/loop = false
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.18),
+"transitions": PackedFloat32Array(0.5, 0.5),
+"update": 1,
+"values": [360.0, 0.0]
+}
+
+[sub_resource type="Animation" id="2"]
+resource_name = "slide_out"
+length = 0.18
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position:x")
+tracks/0/interp = 1
+tracks/0/loop = false
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.18),
+"transitions": PackedFloat32Array(0.5, 0.5),
+"update": 1,
+"values": [0.0, 360.0]
+}
+
+[sub_resource type="AnimationLibrary" id="3"]
+_anims = {
+"slide_in": SubResource("1"),
+"slide_out": SubResource("2")
+}
+
+[node name="ResourcesPanel" type="Control"]
+layout_mode = 1
+anchors_preset = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -360.0
+offset_top = 60.0
+offset_right = -24.0
+offset_bottom = -60.0
+position = Vector2(360, 0)
+script = ExtResource("1")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("3")
+}
+
+[node name="Panel" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Layout" type="VBoxContainer" parent="Panel"]
+layout_mode = 2
+anchors_preset = 15
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/separation = 16
+
+[node name="Header" type="Label" parent="Panel/Layout"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Resources"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ListScroll" type="ScrollContainer" parent="Panel/Layout"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+vertical_scroll_mode = 2
+
+[node name="Rows" type="VBoxContainer" parent="Panel/Layout/ListScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_constants/separation = 12
+
+[node name="Footer" type="HBoxContainer" parent="Panel/Layout"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+custom_constants/separation = 12
+
+[node name="Hint" type="Label" parent="Panel/Layout/Footer"]
+layout_mode = 2
+text = "Tab / Start = Close    Z = Cancel"
+vertical_alignment = 1

--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -31,6 +31,7 @@ var _cell_type_colors := {
 @onready var _build_controller: BuildController = $BuildController
 @onready var _assign_controller: AssignController = $AssignController
 @onready var _build_menu: BuildRadialMenu = $CanvasLayer/BuildRadialMenu
+@onready var _resources_panel: ResourcesPanel = $CanvasLayer/ResourcesPanel
 
 func _ready() -> void:
     _generate_grid()
@@ -93,7 +94,13 @@ func _update_offset() -> void:
     _grid_offset = get_viewport_rect().size * 0.5 - grid_center
 
 func _unhandled_input(event: InputEvent) -> void:
-    if (_build_menu and _build_menu.is_open()) or (_assign_controller and _assign_controller.is_panel_open()):
+    if event.is_action_pressed("resources_panel_toggle"):
+        if _resources_panel:
+            _resources_panel.toggle()
+        accept_event()
+        return
+
+    if (_build_menu and _build_menu.is_open()) or (_assign_controller and _assign_controller.is_panel_open()) or (_resources_panel and _resources_panel.is_open()):
         return
 
     if event.is_action_pressed("ui_right"):

--- a/scripts/autoload/IconDB.gd
+++ b/scripts/autoload/IconDB.gd
@@ -1,0 +1,41 @@
+extends Node
+class_name IconDB
+
+const RESOURCE_COLORS := {
+    "Honey": Color(0.98, 0.78, 0.24),
+    "Comb": Color(0.95, 0.64, 0.27),
+    "Pollen": Color(0.98, 0.86, 0.38),
+    "NectarCommon": Color(0.79, 0.52, 0.91),
+    "PetalRed": Color(0.92, 0.32, 0.42)
+}
+
+var _icon_cache: Dictionary = {}
+
+func get_icon_for(resource_id: StringName) -> Texture2D:
+    var key := String(resource_id)
+    if _icon_cache.has(key):
+        return _icon_cache[key]
+    var color: Color = RESOURCE_COLORS.get(key, _color_from_string(key))
+    var tex := _make_circle_icon(color)
+    _icon_cache[key] = tex
+    return tex
+
+func _make_circle_icon(color: Color) -> Texture2D:
+    var size := 48
+    var image := Image.create(size, size, false, Image.FORMAT_RGBA8)
+    image.fill(Color(0, 0, 0, 0))
+    var center := Vector2(size, size) * 0.5
+    var radius := float(size) * 0.45
+    for y in size:
+        for x in size:
+            var pos := Vector2(float(x) + 0.5, float(y) + 0.5)
+            if pos.distance_to(center) <= radius:
+                image.set_pixel(x, y, color)
+    return ImageTexture.create_from_image(image)
+
+func _color_from_string(value: String) -> Color:
+    var hash := abs(value.hash())
+    var r := float((hash >> 16) & 0xFF) / 255.0
+    var g := float((hash >> 8) & 0xFF) / 255.0
+    var b := float(hash & 0xFF) / 255.0
+    return Color(r, g, b, 1.0)

--- a/scripts/ui/ResourceRow.gd
+++ b/scripts/ui/ResourceRow.gd
@@ -1,0 +1,59 @@
+extends PanelContainer
+class_name ResourceRow
+
+@onready var icon: TextureRect = $HBox/Icon
+@onready var name_lbl: Label = $HBox/Info/Name
+@onready var qty_lbl: Label = $HBox/Qty
+@onready var bar_bg: ColorRect = $HBox/Info/Bar/Bg
+@onready var bar_fg: ColorRect = $HBox/Info/Bar/Fg
+
+var _pending_pct: float = -1.0
+
+func _ready() -> void:
+    _apply_style()
+    set_process(false)
+
+func _notification(what: int) -> void:
+    if what == NOTIFICATION_RESIZED and _pending_pct >= 0.0:
+        _update_bar_fill(_pending_pct)
+
+func set_icon(tex: Texture2D) -> void:
+    icon.texture = tex
+    icon.visible = tex != null
+
+func set_name_text(t: String) -> void:
+    name_lbl.text = t
+
+func set_values(q: int, c: int) -> void:
+    qty_lbl.text = "%d/%d" % [q, c]
+    var pct := 0.0
+    if c > 0:
+        pct = clamp(float(q) / float(c), 0.0, 1.0)
+    _pending_pct = pct
+    _update_bar_fill(pct)
+    if c > 0 and q >= c:
+        qty_lbl.add_theme_color_override("font_color", Color(1.0, 0.55, 0.55))
+    else:
+        qty_lbl.add_theme_color_override("font_color", Color(1, 1, 1, 0.95))
+
+func _apply_style() -> void:
+    var style := StyleBoxFlat.new()
+    style.bg_color = Color(0.18, 0.16, 0.2, 0.92)
+    style.set_corner_radius_all(16)
+    style.set_border_width_all(1)
+    style.border_color = Color(1.0, 0.75, 0.32, 0.6)
+    add_theme_stylebox_override("panel", style)
+    bar_bg.color = Color(0.08, 0.08, 0.1, 0.85)
+    bar_fg.color = Color(1.0, 0.72, 0.28, 0.9)
+    bar_bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    bar_fg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    bar_fg.visible = false
+
+func _update_bar_fill(pct: float) -> void:
+    if bar_bg == null or bar_fg == null:
+        return
+    var size_x := bar_bg.get_size().x
+    if size_x <= 0:
+        return
+    bar_fg.size = Vector2(size_x * pct, bar_fg.size.y if bar_fg.size.y > 0 else bar_bg.size.y)
+    bar_fg.visible = pct > 0.0

--- a/scripts/ui/ResourcesPanel.gd
+++ b/scripts/ui/ResourcesPanel.gd
@@ -1,0 +1,117 @@
+extends Control
+class_name ResourcesPanel
+
+const SLIDE_IN_ANIM := StringName("slide_in")
+const SLIDE_OUT_ANIM := StringName("slide_out")
+const ROW_SCENE := preload("res://scenes/UI/ResourceRow.tscn")
+
+@onready var anim: AnimationPlayer = $AnimationPlayer
+@onready var panel: PanelContainer = $Panel
+@onready var list_vbox: VBoxContainer = $Panel/Layout/ListScroll/Rows
+@onready var footer_label: Label = $Panel/Layout/Footer/Hint
+
+var _rows: Dictionary = {}
+var _snapshot: Dictionary = {}
+var _is_open: bool = false
+var _closing: bool = false
+
+func _ready() -> void:
+    visible = false
+    set_process_unhandled_input(true)
+    if anim:
+        anim.animation_finished.connect(_on_animation_finished)
+    if not Events.resources_changed.is_connected(_on_resources_changed):
+        Events.resources_changed.connect(_on_resources_changed)
+    _apply_panel_style()
+
+func toggle() -> void:
+    if _is_open and not _closing:
+        _close()
+    else:
+        _open()
+
+func is_open() -> bool:
+    return _is_open and not _closing
+
+func _open() -> void:
+    if _closing:
+        return
+    _is_open = true
+    visible = true
+    raise()
+    if _rows.is_empty():
+        _build_rows()
+    _apply_snapshot()
+    if anim and anim.has_animation(SLIDE_IN_ANIM):
+        anim.play(SLIDE_IN_ANIM)
+    else:
+        position.x = 0
+
+func _close() -> void:
+    if not _is_open or _closing:
+        return
+    _closing = true
+    if anim and anim.has_animation(SLIDE_OUT_ANIM):
+        anim.play(SLIDE_OUT_ANIM)
+    else:
+        _finalize_close()
+
+func _apply_panel_style() -> void:
+    var style := StyleBoxFlat.new()
+    style.bg_color = Color(0.11, 0.1, 0.12, 0.94)
+    style.border_color = Color(1.0, 0.78, 0.32)
+    style.set_border_width_all(2)
+    style.set_corner_radius_all(18)
+    panel.add_theme_stylebox_override("panel", style)
+    footer_label.text = "Tab / Start = Close    Z = Cancel"
+
+func _on_resources_changed(snap: Dictionary) -> void:
+    _snapshot = snap.duplicate(true)
+    if _is_open and not _closing:
+        _apply_snapshot()
+
+func _build_rows() -> void:
+    _rows.clear()
+    var ids: Array[StringName] = ConfigDB.get_resource_ids()
+    for id in ids:
+        var row: ResourceRow = ROW_SCENE.instantiate()
+        row.set_meta("id", id)
+        row.set_icon(IconDB.get_icon_for(id))
+        row.set_name_text(ConfigDB.get_resource_display_name(id))
+        list_vbox.add_child(row)
+        _rows[id] = row
+
+func _apply_snapshot() -> void:
+    if _snapshot.is_empty():
+        _snapshot = GameState.get_resources_snapshot()
+    for id in _rows.keys():
+        var row: ResourceRow = _rows[id]
+        if not is_instance_valid(row):
+            continue
+        var entry: Dictionary = _snapshot.get(id, {})
+        if entry.is_empty():
+            entry = {
+                "qty": 0,
+                "cap": ConfigDB.get_resource_cap(id),
+                "display_name": ConfigDB.get_resource_display_name(id)
+            }
+        row.set_name_text(String(entry.get("display_name", ConfigDB.get_resource_display_name(id))))
+        row.set_values(int(entry.get("qty", 0)), int(entry.get("cap", 0)))
+
+func _unhandled_input(event: InputEvent) -> void:
+    if not _is_open or _closing:
+        return
+    if event.is_action_pressed("cancel") or event.is_action_pressed("resources_panel_toggle"):
+        _close()
+        accept_event()
+
+func _on_animation_finished(name: StringName) -> void:
+    if name == SLIDE_OUT_ANIM:
+        _finalize_close()
+    elif name == SLIDE_IN_ANIM:
+        position.x = 0
+
+func _finalize_close() -> void:
+    visible = false
+    _is_open = false
+    _closing = false


### PR DESCRIPTION
## Summary
- add a resources configuration file and extend ConfigDB/GameState to expose quantities with capacities
- create icon generation support plus resource row/panel scenes with slide-in animations and live updates
- wire the resources panel into the UI layer with a Tab/Start toggle and block gameplay input while open

## Testing
- godot --headless --quit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc928303ec8322a9dc4c3fffd4b258