### PR TITLE
Handle resources panel toggle input

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -97,7 +97,9 @@ func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed("resources_panel_toggle"):
         if _resources_panel:
             _resources_panel.toggle()
-        accept_event()
+        var viewport := get_viewport()
+        if viewport:
+            viewport.set_input_as_handled()
         return
 
     if (_build_menu and _build_menu.is_open()) or (_assign_controller and _assign_controller.is_panel_open()) or (_resources_panel and _resources_panel.is_open()):


### PR DESCRIPTION
## Summary
- replace the HexGridTest resources panel toggle handler to mark the event as handled using the viewport
- avoid calling the removed accept_event helper when toggling the resources panel

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc9b75bef0832290b992cd86921efd