### PR TITLE
Replace deprecated raise call on resources panel

### DIFF
--- a/scripts/ui/ResourcesPanel.gd
+++ b/scripts/ui/ResourcesPanel.gd
@@ -38,7 +38,7 @@ func _open() -> void:
         return
     _is_open = true
     visible = true
-    raise()
+    move_to_front()
     if _rows.is_empty():
         _build_rows()
     _apply_snapshot()


### PR DESCRIPTION
## Summary
- replace the deprecated CanvasItem.raise call in the resources panel with move_to_front to keep the panel on top when opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc9e2a40f08322a344a89ed3669620