### PR TITLE
Fix resource row icon initialization order

### DIFF
--- a/scripts/ui/ResourcesPanel.gd
+++ b/scripts/ui/ResourcesPanel.gd
@@ -76,9 +76,9 @@ func _build_rows() -> void:
     for id in ids:
         var row: ResourceRow = ROW_SCENE.instantiate()
         row.set_meta("id", id)
+        list_vbox.add_child(row)
         row.set_icon(IconDB.get_icon_for(id))
         row.set_name_text(ConfigDB.get_resource_display_name(id))
-        list_vbox.add_child(row)
         _rows[id] = row
 
 func _apply_snapshot() -> void:


### PR DESCRIPTION
## Summary
- ensure ResourceRow instances are added to the scene tree before setting their icon
- prevent nil TextureRect references when opening the resources panel via keyboard shortcuts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca368b14883229295b408b8487260