### PR TITLE
Fix ProductionSystem autoload naming conflict

### DIFF
--- a/scripts/systems/ProductionSystem.gd
+++ b/scripts/systems/ProductionSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name ProductionSystem
 
 const HiveSystem := preload("res://scripts/systems/HiveSystem.gd")
 


### PR DESCRIPTION
## Summary
- remove the `class_name ProductionSystem` declaration so the autoload singleton no longer conflicts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccb4478f38832289d6aa497887e13e