### PR TITLE
Fix HarvestController autoload naming conflict

### DIFF
--- a/scripts/autoload/HarvestController.gd
+++ b/scripts/autoload/HarvestController.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name HarvestController
 
 const TICK_INTERVAL := 1.0
 


### PR DESCRIPTION
## Summary
- remove the class_name declaration from the HarvestController autoload to avoid hiding the singleton

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce599d031c8322b5f21a5cd0277313