### PR TITLE
Update overlay pause handling for Godot 4

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -419,7 +419,7 @@ func _show_queen_selection() -> void:
     var overlay: Node = QueenSelectScene.instantiate()
     if overlay == null:
         return
-    overlay.pause_mode = Node.PAUSE_MODE_PROCESS
+    overlay.process_mode = Node.PROCESS_MODE_WHEN_PAUSED
     if overlay.has_signal("queen_confirmed"):
         overlay.connect("queen_confirmed", Callable(self, "_on_queen_confirmed"))
     if overlay.has_signal("selection_closed"):


### PR DESCRIPTION
## Summary
- replace deprecated `pause_mode` constant usage with the Godot 4 `process_mode` equivalent when instantiating the queen selection overlay

## Testing
- not run (Godot tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0d66163708322942b94e10f1c05b1