### PR TITLE
Enable direct specialisation builds from build menu

### DIFF
--- a/scenes/TestHex.tscn
+++ b/scenes/TestHex.tscn
@@ -20,6 +20,7 @@ script = ExtResource("1")
 [node name="BuildController" type="Node" parent="."]
 script = ExtResource("2")
 build_menu_path = NodePath("../CanvasLayer/BuildRadialMenu")
+build_manager_path = NodePath("../BuildManager")
 
 [node name="AssignController" type="Node" parent="."]
 script = ExtResource("4")

--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -278,7 +278,11 @@ func _handle_cell_interaction(cell_id: int, coord: Vector2i) -> void:
         return
     var state: int = int(_cell_states.get(cell_id, BuildState.LOCKED))
     if state == BuildState.AVAILABLE:
-        _attempt_start_build(cell_id)
+        if _build_controller:
+            var world_position_available: Vector2 = _get_cell_center(coord)
+            _build_controller.open_radial(cell_id, world_position_available)
+        else:
+            UIFx.flash_deny()
         return
     if state == BuildState.BUILDING:
         return
@@ -294,12 +298,6 @@ func _handle_cell_interaction(cell_id: int, coord: Vector2i) -> void:
             return
         if _assign_controller:
             _assign_controller.open_panel(cell_id)
-
-func _attempt_start_build(cell_id: int) -> void:
-    if _build_manager == null:
-        push_warning("BuildManager not available; cannot start build")
-        return
-    _build_manager.request_build(cell_id)
 
 func _draw_bee_icons(center: Vector2, icons: Array) -> void:
     if icons.is_empty():

--- a/scripts/controllers/BuildController.gd
+++ b/scripts/controllers/BuildController.gd
@@ -2,13 +2,20 @@ extends Node
 class_name BuildController
 
 @export var build_menu_path: NodePath
+@export var build_manager_path: NodePath
+
+const BUILD_STATE_LOCKED := 0
+const BUILD_STATE_AVAILABLE := 1
 
 var build_menu: BuildRadialMenu
+var build_manager: BuildManager
 var current_cell_id: int = -1
 
 func _ready() -> void:
     if build_menu_path != NodePath():
         build_menu = get_node_or_null(build_menu_path)
+    if build_manager_path != NodePath():
+        build_manager = get_node_or_null(build_manager_path)
     if build_menu:
         build_menu.menu_closed.connect(_on_menu_closed)
         build_menu.build_chosen.connect(_on_build_chosen)
@@ -19,6 +26,10 @@ func is_menu_open() -> bool:
 func open_radial(cell_id: int, world_position: Vector2) -> void:
     current_cell_id = cell_id
     if build_menu:
+        var state: int = GameState.get_hive_cell_state(cell_id, BUILD_STATE_LOCKED)
+        var include_base_cost: bool = state == BUILD_STATE_AVAILABLE
+        var base_cost: Dictionary = include_base_cost ? _get_base_build_cost() : {}
+        build_menu.set_base_cost(base_cost)
         build_menu.open_for_cell(cell_id, world_position)
 
 func close_menu() -> void:
@@ -27,7 +38,24 @@ func close_menu() -> void:
 
 func _on_menu_closed() -> void:
     current_cell_id = -1
+    if build_menu:
+        build_menu.set_base_cost({})
 
-func _on_build_chosen(cell_type: StringName) -> void:
-    # Placeholder hook for future build effects.
-    pass
+func _on_build_chosen(cell_type: StringName, option_index: int) -> void:
+    if current_cell_id == -1:
+        return
+    if build_manager == null:
+        push_warning("BuildManager not assigned; cannot start build")
+        if build_menu:
+            build_menu.show_unaffordable_feedback(option_index)
+        return
+    var success: bool = build_manager.request_build(current_cell_id, cell_type)
+    if success:
+        build_menu.close()
+    elif build_menu:
+        build_menu.show_unaffordable_feedback(option_index)
+
+func _get_base_build_cost() -> Dictionary:
+    if build_manager and build_manager.build_config:
+        return build_manager.build_config.get_cost_dictionary()
+    return {}

--- a/scripts/controllers/BuildManager.gd
+++ b/scripts/controllers/BuildManager.gd
@@ -7,38 +7,73 @@ signal build_started(cell_id: int)
 signal build_finished(cell_id: int)
 signal build_failed(cell_id: int)
 
+const HiveSystem := preload("res://scripts/systems/HiveSystem.gd")
+const MergeSystem := preload("res://scripts/systems/MergeSystem.gd")
+
+const BUILD_STATE_LOCKED := 0
+const BUILD_STATE_AVAILABLE := 1
+const BUILD_STATE_BUILT := 3
+
 var _active_builds: Dictionary = {}
 
-func request_build(cell_id: int) -> bool:
+func request_build(cell_id: int, cell_type: StringName) -> bool:
     if build_config == null:
         push_warning("BuildConfig not assigned; cannot start build")
+        emit_signal("build_failed", cell_id)
+        return false
+    if String(cell_type).is_empty():
+        push_warning("Invalid cell type requested for build")
+        emit_signal("build_failed", cell_id)
         return false
     if _active_builds.has(cell_id):
         return false
-    var cost: Dictionary = build_config.get_cost_dictionary()
-    if not cost.is_empty():
-        if not GameState.can_spend(cost):
+    var current_type: String = HiveSystem.get_cell_type(cell_id)
+    if current_type != String(HiveSystem.EMPTY_TYPE) and current_type != "Empty":
+        UIFx.flash_deny()
+        emit_signal("build_failed", cell_id)
+        return false
+    var state: int = GameState.get_hive_cell_state(cell_id, BUILD_STATE_LOCKED)
+    var is_new_build: bool = state == BUILD_STATE_AVAILABLE
+    var is_existing_empty: bool = state == BUILD_STATE_BUILT and current_type == String(HiveSystem.EMPTY_TYPE)
+    if not is_new_build and not is_existing_empty:
+        UIFx.flash_deny()
+        emit_signal("build_failed", cell_id)
+        return false
+    var base_cost: Dictionary = is_new_build ? build_config.get_cost_dictionary() : {}
+    var specialization_cost: Dictionary = ConfigDB.get_cell_cost(cell_type)
+    var total_cost: Dictionary = _combine_costs(base_cost, specialization_cost)
+    if not total_cost.is_empty():
+        if not GameState.can_spend(total_cost):
             _notify_insufficient_resources(cell_id)
             return false
-        if not GameState.spend(cost):
+        if not GameState.spend(total_cost):
             _notify_insufficient_resources(cell_id)
             return false
+    if is_existing_empty:
+        _complete_build(cell_id, cell_type)
+        Events.cell_built.emit(cell_id, cell_type)
+        return true
     var duration: float = max(build_config.build_time_sec, 0.0)
     if duration <= 0.0:
         emit_signal("build_started", cell_id)
+        _complete_build(cell_id, cell_type)
         emit_signal("build_finished", cell_id)
-        Events.cell_built.emit(cell_id, StringName("Empty"))
+        Events.cell_built.emit(cell_id, cell_type)
         return true
     var timer: SceneTreeTimer = get_tree().create_timer(duration)
     if timer == null:
         push_warning("Failed to create build timer")
         emit_signal("build_failed", cell_id)
         return false
-    _active_builds[cell_id] = timer
+    _active_builds[cell_id] = {
+        "timer": timer,
+        "cell_type": cell_type
+    }
     timer.timeout.connect(func() -> void:
         _active_builds.erase(cell_id)
+        _complete_build(cell_id, cell_type)
         emit_signal("build_finished", cell_id)
-        Events.cell_built.emit(cell_id, StringName("Empty"))
+        Events.cell_built.emit(cell_id, cell_type)
     , CONNECT_ONE_SHOT)
     emit_signal("build_started", cell_id)
     return true
@@ -49,12 +84,33 @@ func is_building(cell_id: int) -> bool:
 func get_progress(cell_id: int) -> float:
     if not _active_builds.has(cell_id):
         return 0.0
-    var timer: SceneTreeTimer = _active_builds.get(cell_id)
+    var data: Variant = _active_builds.get(cell_id)
+    if typeof(data) != TYPE_DICTIONARY:
+        return 0.0
+    var timer: SceneTreeTimer = data.get("timer", null)
     if timer == null:
         return 0.0
     var total: float = max(build_config.build_time_sec, 0.0001)
     var remaining: float = max(timer.time_left, 0.0)
     return clamp(1.0 - remaining / total, 0.0, 1.0)
+
+func _complete_build(cell_id: int, cell_type: StringName) -> void:
+    HiveSystem.convert_cell_type(cell_id, cell_type)
+    MergeSystem.recompute_for(cell_id)
+
+func _combine_costs(a: Dictionary, b: Dictionary) -> Dictionary:
+    var combined: Dictionary = {}
+    for key in a.keys():
+        var resource: StringName = key if typeof(key) == TYPE_STRING_NAME else StringName(String(key))
+        var amount: float = float(a[key])
+        combined[resource] = float(combined.get(resource, 0.0)) + amount
+    for key in b.keys():
+        var resource_b: StringName = key if typeof(key) == TYPE_STRING_NAME else StringName(String(key))
+        var amount_b: float = float(b[key])
+        combined[resource_b] = float(combined.get(resource_b, 0.0)) + amount_b
+    for key in combined.keys():
+        combined[key] = int(round(float(combined[key])))
+    return combined
 
 func _notify_insufficient_resources(cell_id: int) -> void:
     UIFx.flash_deny()


### PR DESCRIPTION
## Summary
- update the build flow so choosing a specialisation triggers BuildManager to construct the selected cell directly
- show combined base and specialisation costs in the build radial menu while delegating spending to BuildManager
- wire BuildController/scene configuration so available cells open the menu instead of placing an empty cell first

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0e787e8d88322be6047b1ee16b03b