### PR TITLE
Fix GDScript parsing errors and duplicate function

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -189,7 +189,7 @@ func _process(delta: float) -> void:
     for cell_id in _cell_states.keys():
         if int(_cell_states[cell_id]) != BuildState.BUILDING:
             continue
-        var progress := _build_manager.get_progress(cell_id)
+        var progress: float = _build_manager.get_progress(cell_id)
         _building_progress[cell_id] = progress
         has_building = true
     if has_building:

--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -564,11 +564,14 @@ func get_boss_cfg() -> Dictionary:
 func get_traits_cfg() -> Dictionary:
     return _traits_cfg.duplicate(true)
 
-func eggs_get_traits_per_rarity(rarity: StringName) -> int:
-    var key: String = String(rarity)
-    if key.is_empty():
-        key = "Common"
-    return int(_traits_per_rarity.get(key, 0))
+func eggs_get_traits_per_rarity(tier: StringName) -> int:
+    var key_string: String = String(tier)
+    if key_string.is_empty():
+        key_string = "Common"
+    var key: StringName = StringName(key_string)
+    if _egg_traits_per_rarity.has(key):
+        return int(_egg_traits_per_rarity[key])
+    return int(_egg_traits_per_rarity.get(key_string, 0))
 
 func _is_buildable(def: Dictionary) -> bool:
     if def.is_empty():
@@ -596,9 +599,6 @@ func eggs_get_hatch_secs(tier: StringName) -> float:
 
 func eggs_bump_prob(key: String) -> float:
     return float(_egg_bump_probs.get(key, 0.0))
-
-func eggs_get_traits_per_rarity(tier: StringName) -> int:
-    return int(_egg_traits_per_rarity.get(tier, 0))
 
 func eggs_get_rarity_outline_color(tier: StringName) -> Color:
     var entry: Dictionary = _egg_rarity_visuals.get(tier, {})

--- a/scripts/controllers/BuildController.gd
+++ b/scripts/controllers/BuildController.gd
@@ -28,7 +28,9 @@ func open_radial(cell_id: int, world_position: Vector2) -> void:
     if build_menu:
         var state: int = GameState.get_hive_cell_state(cell_id, BUILD_STATE_LOCKED)
         var include_base_cost: bool = state == BUILD_STATE_AVAILABLE
-        var base_cost: Dictionary = include_base_cost ? _get_base_build_cost() : {}
+        var base_cost: Dictionary = {}
+        if include_base_cost:
+            base_cost = _get_base_build_cost()
         build_menu.set_base_cost(base_cost)
         build_menu.open_for_cell(cell_id, world_position)
 

--- a/scripts/controllers/BuildManager.gd
+++ b/scripts/controllers/BuildManager.gd
@@ -40,7 +40,9 @@ func request_build(cell_id: int, cell_type: StringName) -> bool:
         UIFx.flash_deny()
         emit_signal("build_failed", cell_id)
         return false
-    var base_cost: Dictionary = is_new_build ? build_config.get_cost_dictionary() : {}
+    var base_cost: Dictionary = {}
+    if is_new_build:
+        base_cost = build_config.get_cost_dictionary()
     var specialization_cost: Dictionary = ConfigDB.get_cell_cost(cell_type)
     var total_cost: Dictionary = _combine_costs(base_cost, specialization_cost)
     var is_brood: bool = cell_type == StringName("Brood")


### PR DESCRIPTION
## Summary
- replace invalid ternary operators in build controller scripts with explicit assignments
- add a float type hint when caching build progress in HexGridTest
- consolidate duplicate egg trait lookup into a single function that handles defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0fc13589883229bdcff499f2084c4