### PR TITLE
Fix TestHex scene references and load traits configuration

### DIFF
--- a/scenes/TestHex.tscn
+++ b/scenes/TestHex.tscn
@@ -1,5 +1,5 @@
 
-[gd_scene load_steps=14 format=3]
+[gd_scene load_steps=17 format=3]
 
 
 [ext_resource type="Script" path="res://scripts/HexGridTest.gd" id="1"]
@@ -16,6 +16,9 @@
 [ext_resource type="PackedScene" path="res://scenes/UI/QueenFeedPanel.tscn" id="12"]
 [ext_resource type="PackedScene" path="res://scenes/UI/ThreatBanner.tscn" id="13"]
 [ext_resource type="PackedScene" path="res://scenes/UI/ThreatResolvePanel.tscn" id="14"]
+[ext_resource type="Script" path="res://scripts/controllers/BroodController.gd" id="15"]
+[ext_resource type="PackedScene" path="res://scenes/UI/BroodInsertPanel.tscn" id="16"]
+[ext_resource type="PackedScene" path="res://scenes/UI/InventoryPanel.tscn" id="17"]
 
 
 [node name="TestHex" type="Node2D"]
@@ -39,7 +42,7 @@ script = ExtResource("11")
 panel_path = NodePath("../CanvasLayer/QueenFeedPanel")
 
 [node name="BroodController" type="Node" parent="."]
-script = ExtResource("16")
+script = ExtResource("15")
 panel_path = NodePath("../CanvasLayer/BroodInsertPanel")
 
 [node name="BuildManager" type="Node" parent="."]
@@ -64,10 +67,10 @@ visible = false
 [node name="QueenFeedPanel" parent="CanvasLayer" instance=ExtResource("12")]
 visible = false
 
-[node name="BroodInsertPanel" parent="CanvasLayer" instance=ExtResource("14")]
+[node name="BroodInsertPanel" parent="CanvasLayer" instance=ExtResource("16")]
 visible = false
 
-[node name="InventoryPanel" parent="CanvasLayer" instance=ExtResource("15")]
+[node name="InventoryPanel" parent="CanvasLayer" instance=ExtResource("17")]
 
 [node name="ThreatBanner" parent="CanvasLayer" instance=ExtResource("13")]
 


### PR DESCRIPTION
## Summary
- add the missing Brood controller, panel, and inventory resources to the TestHex scene
- parse the traits configuration file during ConfigDB initialization and expose its data safely

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0fd1c543c8322ba196d14c6759d05