### PR TITLE
Fix trait parsing dictionary construction

### DIFF
--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -307,11 +307,12 @@ func load_traits() -> void:
             var id_string: String = String(id_value)
             if id_string.is_empty():
                 continue
-            var trait: Dictionary = {}
-            trait["id"] = StringName(id_string)
-            trait["name"] = String(entry.get("name", id_string))
-            trait["desc"] = String(entry.get("desc", ""))
-            var effects: Dictionary = {}
+            var trait := {
+                "id": StringName(id_string),
+                "name": String(entry.get("name", id_string)),
+                "desc": String(entry.get("desc", "")),
+            }
+            var effects := {}
             var effects_value: Variant = entry.get("effects", {})
             if typeof(effects_value) == TYPE_DICTIONARY:
                 for key in effects_value.keys():


### PR DESCRIPTION
## Summary
- rebuild the trait dictionary using an inline literal to avoid parser confusion
- simplify effects dictionary initialization when loading trait data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0fe8c37a883229fc0e96696721d33