### PR TITLE
Fix trait parsing dictionary construction

### DIFF
--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -307,12 +307,11 @@ func load_traits() -> void:
             var id_string: String = String(id_value)
             if id_string.is_empty():
                 continue
-            var trait := {
-                "id": StringName(id_string),
-                "name": String(entry.get("name", id_string)),
-                "desc": String(entry.get("desc", "")),
-            }
-            var effects := {}
+            var trait: Dictionary = {}
+            trait["id"] = StringName(id_string)
+            trait["name"] = String(entry.get("name", id_string))
+            trait["desc"] = String(entry.get("desc", ""))
+            var effects: Dictionary = {}
             var effects_value: Variant = entry.get("effects", {})
             if typeof(effects_value) == TYPE_DICTIONARY:
                 for key in effects_value.keys():


### PR DESCRIPTION
## Summary
- avoid multi-line literal when building trait dictionaries to satisfy parser
- ensure effects map starts as an explicit Dictionary before assignment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d10020f96c832295616186d006fb18