### PR TITLE
Fix reserved keyword conflict in ConfigDB trait loader

### DIFF
--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -307,17 +307,17 @@ func load_traits() -> void:
             var id_string: String = String(id_value)
             if id_string.is_empty():
                 continue
-            var trait: Dictionary = {}
-            trait["id"] = StringName(id_string)
-            trait["name"] = String(entry.get("name", id_string))
-            trait["desc"] = String(entry.get("desc", ""))
+            var trait_entry: Dictionary = {}
+            trait_entry["id"] = StringName(id_string)
+            trait_entry["name"] = String(entry.get("name", id_string))
+            trait_entry["desc"] = String(entry.get("desc", ""))
             var effects: Dictionary = {}
             var effects_value: Variant = entry.get("effects", {})
             if typeof(effects_value) == TYPE_DICTIONARY:
                 for key in effects_value.keys():
                     effects[StringName(String(key))] = effects_value.get(key)
-            trait["effects"] = effects
-            traits_list.append(trait)
+            trait_entry["effects"] = effects
+            traits_list.append(trait_entry)
     var rarity_pools: Dictionary = {}
     var pools_value: Variant = parsed.get("rarity_pools", {})
     if typeof(pools_value) == TYPE_DICTIONARY:


### PR DESCRIPTION
## Summary
- rename the local trait dictionary to `trait_entry` while building the trait list
- keep effect processing intact by writing back into the renamed dictionary before appending

## Testing
- not run (godot command-line tools not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1010b94ec8322b87d28b0914d5109