### PR TITLE
Fix TraitsSystem autoload class conflict

### DIFF
--- a/scripts/systems/TraitsSystem.gd
+++ b/scripts/systems/TraitsSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name TraitsSystem
 
 const KEY_HARVEST_TRICKLE_MULTIPLIER := StringName("harvest_trickle_multiplier")
 const DEFAULT_KEY_GATHER_MULTIPLIER := StringName("gather_multiplier")


### PR DESCRIPTION
## Summary
- remove the `class_name` declaration from `TraitsSystem.gd` so the autoload singleton is not shadowed by the class

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d128495b788322b2430f3460b00806