### PR TITLE
Remove stray file end markers

### DIFF
--- a/scenes/UI/ThreatBanner.tscn
+++ b/scenes/UI/ThreatBanner.tscn
@@ -95,4 +95,3 @@ visible = false
 horizontal_alignment = 1
 vertical_alignment = 1
 
-*** End File

--- a/scripts/systems/DefenseSystem.gd
+++ b/scripts/systems/DefenseSystem.gd
@@ -135,4 +135,3 @@ func _on_cell_neighbors_changed(cell_ids: Array) -> void:
         var cell_id: int = int(value)
         _refresh_post(cell_id)
 
-*** End File

--- a/scripts/systems/ThreatSystem.gd
+++ b/scripts/systems/ThreatSystem.gd
@@ -214,4 +214,3 @@ func _get_min_spawn_gap() -> float:
 
 func _on_game_over(_reason: String) -> void:
     _boss_in_progress = false
-*** End File

--- a/scripts/ui/ThreatBanner.gd
+++ b/scripts/ui/ThreatBanner.gd
@@ -209,4 +209,3 @@ func _format_time(seconds: float) -> String:
     var minutes: int = total / 60
     var rem: int = total % 60
     return "%02d:%02d" % [minutes, rem]
-*** End File


### PR DESCRIPTION
## Summary
- remove stray `*** End File` markers left in various Godot scripts and a scene file
- resolve unexpected token parse errors caused by the markers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d129e720f88322b920a87e594e6d2c