### PR TITLE
Fix reserved keyword usage in TraitsSystem

### DIFF
--- a/scripts/systems/TraitsSystem.gd
+++ b/scripts/systems/TraitsSystem.gd
@@ -177,10 +177,10 @@ func _get_rarity_pool(rarity: StringName) -> Array:
     return fallback
 
 func _trait_effect_float(trait_id: StringName, key: StringName, fallback: float) -> float:
-    var trait: Dictionary = _traits_by_id.get(trait_id, {})
-    if trait.is_empty():
+    var trait_data: Dictionary = _traits_by_id.get(trait_id, {})
+    if trait_data.is_empty():
         return fallback
-    var effects_value: Variant = trait.get("effects", {})
+    var effects_value: Variant = trait_data.get("effects", {})
     if typeof(effects_value) != TYPE_DICTIONARY:
         return fallback
     var value: Variant = effects_value.get(key, null)


### PR DESCRIPTION
## Summary
- rename the local trait dictionary to trait_data to avoid using the new GDScript `trait` keyword

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c7787be0832283cf820040d4216a