### PR TITLE
Remove conflicting TraitsSystem class name

### DIFF
--- a/scripts/systems/TraitsSystem.gd
+++ b/scripts/systems/TraitsSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name TraitsSystem
 
 const TRAIT_CONSTRUCTION := StringName("Construction")
 const TRAIT_GATHER := StringName("Gather")


### PR DESCRIPTION
## Summary
- remove the `class_name` declaration from the TraitsSystem autoload to avoid hiding the singleton and allow calls to work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ccbf47608322a9cfde4d17494b8a