### PR TITLE
Remove class_name from ThreatSystem autoload

### DIFF
--- a/scripts/systems/ThreatSystem.gd
+++ b/scripts/systems/ThreatSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name ThreatSystem
 
 var _rng := RandomNumberGenerator.new()
 var _tick_timer: Timer


### PR DESCRIPTION
## Summary
- remove the ThreatSystem class_name declaration so the autoload singleton name no longer conflicts with a registered class

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1d9f5c3e48322bb702d443502c6fa