### PR TITLE
Remove class name from InventorySystem autoload

### DIFF
--- a/scripts/systems/InventorySystem.gd
+++ b/scripts/systems/InventorySystem.gd
@@ -1,6 +1,4 @@
 extends Node
-class_name InventorySystem
-
 var _items: Dictionary = {}
 var _item_ids: Array[StringName] = []
 


### PR DESCRIPTION
## Summary
- remove the `class_name InventorySystem` declaration from the autoloaded script to avoid conflicts with the singleton instance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1dbb7f9748322867a14881d878c78