### PR TITLE
Fix autoload class conflict and type array initializations

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -12,7 +12,7 @@ const SEAT_TYPE := StringName("QueenSeat")
 @export var selection_color: Color = Color(1.0, 0.6, 0.0)
 @export var selection_line_width: float = 4.0
 
-var _hex_coords: Array[Vector2i] = []
+var _hex_coords: Array[Vector2i] = Array[Vector2i]()
 var _positions: Dictionary = {}
 var _cell_ids_by_coord: Dictionary = {}
 var _coords_by_id: Dictionary = {}

--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -20,13 +20,13 @@ const BUILDING_ASSIGNMENT_DEFAULTS := {
 }
 
 var _cell_defs: Dictionary = {}
-var _buildable_ids: Array[StringName] = []
-var _resource_defs: Array[Dictionary] = []
+var _buildable_ids: Array[StringName] = Array[StringName]()
+var _resource_defs: Array[Dictionary] = Array[Dictionary]()
 var _resource_lookup: Dictionary = {}
-var _harvest_offers: Array[Dictionary] = []
+var _harvest_offers: Array[Dictionary] = Array[Dictionary]()
 var _harvest_lookup: Dictionary = {}
-var _queen_defs: Array[Dictionary] = []
-var _threat_defs: Array[Dictionary] = []
+var _queen_defs: Array[Dictionary] = Array[Dictionary]()
+var _threat_defs: Array[Dictionary] = Array[Dictionary]()
 var _threat_lookup: Dictionary = {}
 var _threat_weights: Dictionary = {}
 var _threat_global: Dictionary = {}
@@ -37,7 +37,7 @@ var _egg_hatch_seconds: Dictionary = {}
 var _egg_bump_probs: Dictionary = {}
 var _egg_rarity_visuals: Dictionary = {}
 var _egg_traits_per_rarity: Dictionary = {}
-var _item_ids: Array[StringName] = []
+var _item_ids: Array[StringName] = Array[StringName]()
 
 func _ready() -> void:
     load_cells()
@@ -295,7 +295,7 @@ func load_traits() -> void:
     if typeof(parsed) != TYPE_DICTIONARY:
         push_warning("Invalid traits.json contents")
         return
-    var traits_list: Array[Dictionary] = []
+    var traits_list: Array[Dictionary] = Array[Dictionary]()
     var traits_value: Variant = parsed.get("traits", [])
     if typeof(traits_value) == TYPE_ARRAY:
         for entry in traits_value:
@@ -323,7 +323,7 @@ func load_traits() -> void:
     if typeof(pools_value) == TYPE_DICTIONARY:
         for key in pools_value.keys():
             var pool_id: String = String(key)
-            var pool_entries: Array[Dictionary] = []
+            var pool_entries: Array[Dictionary] = Array[Dictionary]()
             var pool_value: Variant = pools_value.get(key, [])
             if typeof(pool_value) != TYPE_ARRAY:
                 continue
@@ -581,7 +581,7 @@ func get_efficiency(building_type: StringName) -> int:
     return int(entry.get("efficiency", 0))
 
 func get_resource_ids() -> Array[StringName]:
-    var ids: Array[StringName] = []
+    var ids: Array[StringName] = Array[StringName]()
     for def in _resource_defs:
         var id: StringName = def.get("id", StringName(""))
         if id != StringName(""):
@@ -607,7 +607,7 @@ func get_resource_short_name(resource_id: StringName) -> String:
     return get_resource_display_name(resource_id)
 
 func get_harvest_offers() -> Array[Dictionary]:
-    var list: Array[Dictionary] = []
+    var list: Array[Dictionary] = Array[Dictionary]()
     for contract in _harvest_offers:
         list.append(contract.duplicate(true))
     return list
@@ -624,7 +624,7 @@ func get_harvest_outputs(offer_id: StringName) -> Dictionary:
     return {}
 
 func get_queens() -> Array[Dictionary]:
-    var list: Array[Dictionary] = []
+    var list: Array[Dictionary] = Array[Dictionary]()
     for entry in _queen_defs:
         list.append(entry.duplicate(true))
     return list

--- a/scripts/autoload/GameState.gd
+++ b/scripts/autoload/GameState.gd
@@ -391,7 +391,7 @@ func get_free_gatherers() -> int:
     return max(total_assigned - _reserved_gatherers.size(), 0)
 
 func reserve_gatherers(amount: int) -> Array[int]:
-    var reserved: Array[int] = []
+    var reserved: Array[int] = Array[int]()
     if amount <= 0:
         return reserved
     _prune_reserved_gatherers()
@@ -407,7 +407,7 @@ func reserve_gatherers(amount: int) -> Array[int]:
     return reserved
 
 func free_gatherers(value: Variant) -> void:
-    var ids: Array[int] = []
+    var ids: Array[int] = Array[int]()
     if typeof(value) == TYPE_ARRAY:
         for entry in value:
             ids.append(int(entry))
@@ -464,7 +464,7 @@ func _get_total_assigned_gatherers() -> int:
     return total
 
 func _get_gatherer_bee_ids() -> Array[int]:
-    var ids: Array[int] = []
+    var ids: Array[int] = Array[int]()
     var cells: Dictionary = HiveSystem.get_cells()
     for entry in cells.values():
         if String(entry.get("type", "")) != "GatheringHut":
@@ -484,7 +484,7 @@ func _get_available_gatherer_ids() -> Array[int]:
     _prune_reserved_gatherers()
     var ids: Array[int] = _get_gatherer_bee_ids()
     ids.sort()
-    var available: Array[int] = []
+    var available: Array[int] = Array[int]()
     for bee_id in ids:
         if not _reserved_gatherers.has(bee_id):
             available.append(int(bee_id))
@@ -497,7 +497,7 @@ func _prune_reserved_gatherers() -> void:
     var gatherer_set: Dictionary = {}
     for bee_id in gatherers:
         gatherer_set[bee_id] = true
-    var to_remove: Array[int] = []
+    var to_remove: Array[int] = Array[int]()
     for key in _reserved_gatherers.keys():
         var bee_id: int = int(key)
         if not gatherer_set.has(bee_id):
@@ -589,7 +589,7 @@ func _emit_bees_changed() -> void:
         Events.bees_changed.emit(get_bees_snapshot())
 
 func _normalize_traits(value: Variant) -> Array[StringName]:
-    var traits: Array[StringName] = []
+    var traits: Array[StringName] = Array[StringName]()
     var items: Array = []
     if typeof(value) == TYPE_ARRAY:
         items = value

--- a/scripts/models/BeeModel.gd
+++ b/scripts/models/BeeModel.gd
@@ -3,7 +3,7 @@ class_name BeeModel
 
 var id: int = 0
 var rarity: StringName = &"Common"
-var traits: Array[StringName] = []
+var traits: Array[StringName] = Array[StringName]()
 
 func set_traits(values: Array) -> void:
     traits.clear()

--- a/scripts/systems/EggSystem.gd
+++ b/scripts/systems/EggSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name EggSystem
 
 const BROOD_TYPE := StringName("Brood")
 const DAMAGED_TYPE := StringName("Damaged")

--- a/scripts/systems/InventorySystem.gd
+++ b/scripts/systems/InventorySystem.gd
@@ -1,6 +1,6 @@
 extends Node
 var _items: Dictionary = {}
-var _item_ids: Array[StringName] = []
+var _item_ids: Array[StringName] = Array[StringName]()
 
 func _ready() -> void:
     reset()

--- a/scripts/systems/MergeSystem.gd
+++ b/scripts/systems/MergeSystem.gd
@@ -41,7 +41,7 @@ static func same_type_neighbor_count(cell_id: int) -> int:
     return count
 
 static func neighbor_ids(cell_id: int) -> Array[int]:
-    var result: Array[int] = []
+    var result: Array[int] = Array[int]()
     if cell_id < 0:
         return result
     if HiveSystem.get_cell_entry(cell_id).is_empty():
@@ -61,7 +61,7 @@ static func _collect_affected_cells(cell_id: int) -> Array[int]:
         for neighbor_id in neighbor_ids(cell_id):
             unique[neighbor_id] = true
     var keys: Array = unique.keys()
-    var result: Array[int] = []
+    var result: Array[int] = Array[int]()
     for key in keys:
         result.append(int(key))
     return result

--- a/scripts/systems/ProductionSystem.gd
+++ b/scripts/systems/ProductionSystem.gd
@@ -38,7 +38,7 @@ func _on_assignment_changed(cell_id: int, _bee_id: int) -> void:
 func _on_resources_changed(_snapshot: Dictionary) -> void:
     if _paused_groups.is_empty():
         return
-    var to_resume: Array[int] = []
+    var to_resume: Array[int] = Array[int]()
     for group_id in _paused_groups.keys():
         var gid: int = int(group_id)
         if _can_group_resume(gid):

--- a/scripts/systems/TraitsSystem.gd
+++ b/scripts/systems/TraitsSystem.gd
@@ -32,7 +32,7 @@ func generate_for_rarity(rarity: StringName, count: int, rng: RandomNumberGenera
     if pool.is_empty():
         return []
     var bag: Array = pool.duplicate(true)
-    var out: Array[StringName] = []
+    var out: Array[StringName] = Array[StringName]()
     count = clamp(count, 0, bag.size())
     for i in range(count):
         if bag.is_empty():

--- a/scripts/ui/AssignBeePanel.gd
+++ b/scripts/ui/AssignBeePanel.gd
@@ -191,7 +191,7 @@ func trait_display_name(trait_id: StringName) -> String:
     return id
 
 func _normalize_traits(value: Variant) -> Array[StringName]:
-    var traits: Array[StringName] = []
+    var traits: Array[StringName] = Array[StringName]()
     if typeof(value) != TYPE_ARRAY:
         return traits
     var seen: Dictionary = {}

--- a/scripts/ui/BuildRadialMenu.gd
+++ b/scripts/ui/BuildRadialMenu.gd
@@ -11,11 +11,11 @@ signal menu_closed()
 
 var cell_id: int = -1
 var center: Vector2 = Vector2.ZERO
-var options: Array[StringName] = []
-var angles: Array[float] = []
-var buttons: Array[RadialOptionControl] = []
-var costs: Array[Dictionary] = []
-var affordable: Array[bool] = []
+var options: Array[StringName] = Array[StringName]()
+var angles: Array[float] = Array[float]()
+var buttons: Array[RadialOptionControl] = Array[RadialOptionControl]()
+var costs: Array[Dictionary] = Array[Dictionary]()
+var affordable: Array[bool] = Array[bool]()
 var selected_index: int = -1
 var base_cost: Dictionary = {}
 
@@ -50,7 +50,7 @@ class RadialOptionControl extends Control:
             return "Free"
         var keys: Array = cost.keys()
         keys.sort()
-        var parts: Array[String] = []
+        var parts: Array[String] = Array[String]()
         for key in keys:
             parts.append("%s %s" % [str(cost[key]), key])
         return " / ".join(parts)

--- a/scripts/ui/HarvestPanel.gd
+++ b/scripts/ui/HarvestPanel.gd
@@ -12,7 +12,7 @@ const SLIDE_OUT_ANIMATION := StringName("slide_out")
 @onready var list_container: VBoxContainer = $Panel/Layout/ListScroll/VBox
 @onready var footer_label: Label = $Panel/Layout/Footer/Hint
 
-var _offers: Array[Dictionary] = []
+var _offers: Array[Dictionary] = Array[Dictionary]()
 var _selected: int = 0
 var _is_open: bool = false
 var _closing: bool = false
@@ -225,7 +225,7 @@ func _format_cost_text(value: Variant) -> String:
     for key in dict.keys():
         keys.append(String(key))
     keys.sort()
-    var parts: Array[String] = []
+    var parts: Array[String] = Array[String]()
     for key_string in keys:
         var amount: int = int(dict.get(StringName(key_string), dict.get(key_string, 0)))
         var short_name: String = ConfigDB.get_resource_short_name(StringName(key_string))
@@ -242,7 +242,7 @@ func _format_yield_text(value: Variant) -> String:
     for key in dict.keys():
         keys.append(String(key))
     keys.sort()
-    var parts: Array[String] = []
+    var parts: Array[String] = Array[String]()
     for key_string in keys:
         var amount: int = int(dict.get(StringName(key_string), dict.get(key_string, 0)))
         var short_name: String = ConfigDB.get_resource_short_name(StringName(key_string))

--- a/scripts/ui/QueenFeedPanel.gd
+++ b/scripts/ui/QueenFeedPanel.gd
@@ -58,7 +58,7 @@ func _update_button(button: Button, tier: StringName) -> void:
     var cost: Dictionary = ConfigDB.eggs_get_feed_cost(tier)
     var label: String = String(tier)
     if not cost.is_empty():
-        var parts: Array[String] = []
+        var parts: Array[String] = Array[String]()
         for key in cost.keys():
             parts.append("%d %s" % [int(cost[key]), String(key)])
         label += " (" + ", ".join(parts) + ")"

--- a/scripts/ui/QueenFeedRadialMenu.gd
+++ b/scripts/ui/QueenFeedRadialMenu.gd
@@ -15,11 +15,11 @@ const HONEY_RESOURCE := StringName("Honey")
 const EGG_RESOURCE := StringName("Egg")
 
 var center: Vector2 = Vector2.ZERO
-var options: Array[int] = []
-var angles: Array[float] = []
-var buttons: Array[RadialOptionControl] = []
-var costs: Array[Dictionary] = []
-var affordable: Array[bool] = []
+var options: Array[int] = Array[int]()
+var angles: Array[float] = Array[float]()
+var buttons: Array[RadialOptionControl] = Array[RadialOptionControl]()
+var costs: Array[Dictionary] = Array[Dictionary]()
+var affordable: Array[bool] = Array[bool]()
 var selected_index: int = -1
 
 var _is_open: bool = false
@@ -53,7 +53,7 @@ class RadialOptionControl extends Control:
             return "Free"
         var keys: Array = cost.keys()
         keys.sort()
-        var parts: Array[String] = []
+        var parts: Array[String] = Array[String]()
         for key in keys:
             parts.append("%s %s" % [str(cost[key]), String(key)])
         return " / ".join(parts)


### PR DESCRIPTION
## Summary
- prevent the EggSystem script from declaring a `class_name` that shadows its autoload singleton
- initialize typed arrays with typed constructors across inventory, config, UI, and systems scripts to avoid Variant inference warnings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1dcc906688322a161556e102b5095