### PR TITLE
Remove stray EOF markers from ability UI scripts

### DIFF
--- a/scripts/systems/CandleHallSystem.gd
+++ b/scripts/systems/CandleHallSystem.gd
@@ -144,4 +144,4 @@ func _ensure_unlocked() -> void:
     if typeof(Events) == TYPE_OBJECT:
         Events.abilities_unlocked.emit()
     UIFx.show_toast("Abilities unlocked")
-*** End EOF
+

--- a/scripts/ui/AbilitiesPanel.gd
+++ b/scripts/ui/AbilitiesPanel.gd
@@ -127,4 +127,4 @@ func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed("cancel") or event.is_action_pressed("abilities_panel_toggle"):
         close()
         accept_event()
-*** End EOF
+

--- a/scripts/ui/RadialCandleHall.gd
+++ b/scripts/ui/RadialCandleHall.gd
@@ -179,4 +179,4 @@ func _on_ritual_completed(cell_id: int, _ability_id: StringName) -> void:
         return
     _end_time = 0.0
     _refresh_state()
-*** End EOF
+


### PR DESCRIPTION
## Summary
- remove accidental "*** End EOF" markers from AbilitiesPanel, RadialCandleHall, and CandleHallSystem scripts
- ensure the scripts terminate cleanly with a newline so Godot can parse their global classes

## Testing
- not run (Godot project parsing fix)


------
https://chatgpt.com/codex/tasks/task_e_68d3d8c8334083228cb5a446a36805c3