### PR TITLE
Fix InventoryRow display type inference warning

### DIFF
--- a/scripts/ui/InventoryRow.gd
+++ b/scripts/ui/InventoryRow.gd
@@ -55,6 +55,6 @@ func _format_count(amount: int) -> String:
     return "%d" % max(amount, 0)
 
 func _apply_count(amount: int) -> void:
-    var display := max(amount, 0)
+    var display: int = max(amount, 0)
     count_badge.text = _format_count(display)
     count_badge.visible = display > 0


### PR DESCRIPTION
## Summary
- declare the inventory row display value as an `int` to avoid Variant inference warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3d8eacdb4832294e74770369283ac