### PR TITLE
Fix BuffsSystem autoload conflict

### DIFF
--- a/scripts/systems/BuffsSystem.gd
+++ b/scripts/systems/BuffsSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name BuffsSystem
 
 var _buffs: Dictionary = {}
 var _next_id: int = 1


### PR DESCRIPTION
## Summary
- remove the `class_name` declaration from the BuffsSystem script so the autoload singleton name is not shadowed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3d9b96284832285cad0f7f034e718