### PR TITLE
Refine controller input and unify build cost handling

### DIFF
--- a/resources/build/BuildConfig.tres
+++ b/resources/build/BuildConfig.tres
@@ -4,7 +4,3 @@
 
 [resource]
 script = ExtResource("1")
-cost_honey = 5
-cost_comb = 1
-requires_free_bee = false
-build_time_sec = 3.0

--- a/scripts/controllers/BuildController.gd
+++ b/scripts/controllers/BuildController.gd
@@ -31,11 +31,6 @@ func open_radial(cell_id: int, world_position: Vector2) -> void:
         current_cell_id = -1
         return
     if build_menu:
-        var include_base_cost: bool = state == BUILD_STATE_AVAILABLE
-        var base_cost: Dictionary = {}
-        if include_base_cost:
-            base_cost = _get_base_build_cost()
-        build_menu.set_base_cost(base_cost)
         build_menu.open_for_cell(cell_id, world_position)
 
 func close_menu() -> void:
@@ -44,8 +39,6 @@ func close_menu() -> void:
 
 func _on_menu_closed() -> void:
     current_cell_id = -1
-    if build_menu:
-        build_menu.set_base_cost({})
 
 func _on_build_chosen(cell_type: StringName, option_index: int) -> void:
     if current_cell_id == -1:
@@ -61,7 +54,3 @@ func _on_build_chosen(cell_type: StringName, option_index: int) -> void:
     elif build_menu:
         build_menu.show_unaffordable_feedback(option_index)
 
-func _get_base_build_cost() -> Dictionary:
-    if build_manager and build_manager.build_config:
-        return build_manager.build_config.get_cost_dictionary()
-    return {}

--- a/scripts/hive/BuildConfig.gd
+++ b/scripts/hive/BuildConfig.gd
@@ -1,17 +1,8 @@
 extends Resource
 class_name BuildConfig
 
-@export var cost_honey: int = 5
-@export var cost_comb: int = 1
-@export var requires_free_bee: bool = false
-@export var build_time_sec: float = 3.0
 @export var sfx_click: AudioStream
 @export var sfx_build_complete: AudioStream
 
 func get_cost_dictionary() -> Dictionary:
-    var cost: Dictionary = {}
-    if cost_honey > 0:
-        cost["Honey"] = cost_honey
-    if cost_comb > 0:
-        cost["Comb"] = cost_comb
-    return cost
+    return {}

--- a/scripts/systems/CostPolicy.gd
+++ b/scripts/systems/CostPolicy.gd
@@ -1,0 +1,27 @@
+extends RefCounted
+class_name CostPolicy
+
+static func get_empty_build_cost() -> Dictionary:
+    var task_cfg: Dictionary = ConfigDB.get_cell_build_task(StringName("Empty"))
+    var cost_value: Variant = task_cfg.get("cost", {})
+    if typeof(cost_value) == TYPE_DICTIONARY:
+        return cost_value.duplicate(true)
+    return {}
+
+static func charge_for_empty_build() -> bool:
+    var cost: Dictionary = get_empty_build_cost()
+    if cost.is_empty():
+        return true
+    return GameState.spend(cost)
+
+static func get_conversion_cost(cell_type: StringName) -> Dictionary:
+    var cost: Dictionary = ConfigDB.get_cell_cost(cell_type)
+    if cost.is_empty():
+        return {}
+    return cost.duplicate(true)
+
+static func charge_for_conversion(cell_type: StringName) -> bool:
+    var cost: Dictionary = get_conversion_cost(cell_type)
+    if cost.is_empty():
+        return true
+    return GameState.spend(cost)

--- a/scripts/systems/WorkerTasks.gd
+++ b/scripts/systems/WorkerTasks.gd
@@ -14,6 +14,7 @@ const TRAIT_CONSTRUCTION := StringName("Construction")
 const TASK_PROGRESS_SCENE := preload("res://scenes/UI/TaskProgress.tscn")
 
 const MergeSystem := preload("res://scripts/systems/MergeSystem.gd")
+const CostPolicy := preload("res://scripts/systems/CostPolicy.gd")
 
 static var _tasks: Dictionary = {}
 
@@ -31,7 +32,7 @@ static func start_build(cell_id: int) -> bool:
     var cfg: Dictionary = ConfigDB.get_cell_build_task(HiveSystem.EMPTY_TYPE)
     if cfg.is_empty():
         return false
-    var cost: Dictionary = cfg.get("cost", {})
+    var cost: Dictionary = CostPolicy.get_empty_build_cost()
     if not cost.is_empty() and not GameState.can_spend(cost):
         return false
     var bee_id: int = GameState.get_free_bee_id()
@@ -39,7 +40,7 @@ static func start_build(cell_id: int) -> bool:
         return false
     if not GameState.reserve_bee(bee_id):
         return false
-    if not cost.is_empty() and not GameState.spend(cost):
+    if not cost.is_empty() and not CostPolicy.charge_for_empty_build():
         GameState.release_bee(bee_id)
         return false
     var base_seconds: float = float(cfg.get("seconds", 0.0))

--- a/scripts/ui/BuildRadialMenu.gd
+++ b/scripts/ui/BuildRadialMenu.gd
@@ -17,7 +17,6 @@ var buttons: Array[RadialOptionControl] = []
 var costs: Array[Dictionary] = []
 var affordable: Array[bool] = []
 var selected_index: int = -1
-var base_cost: Dictionary = {}
 
 var _is_open: bool = false
 var _open_tween: Tween = null
@@ -139,9 +138,9 @@ func _prepare_options() -> void:
         var angle: float = start_angle + float(i) * TAU / float(count)
         angles.append(angle)
         var specialization_cost: Dictionary = ConfigDB.get_cell_cost(options[i])
-        var total_cost: Dictionary = _combine_costs(base_cost, specialization_cost)
-        costs.append(total_cost)
-        affordable.append(GameState.can_afford(total_cost))
+        var cost_copy: Dictionary = specialization_cost.duplicate(true)
+        costs.append(cost_copy)
+        affordable.append(GameState.can_afford(cost_copy))
     selected_index = clamp(selected_index, 0, count - 1)
     if selected_index < 0:
         selected_index = 0
@@ -255,7 +254,6 @@ func _on_close_finished() -> void:
     _is_open = false
     visible = false
     selection_ring.visible = false
-    base_cost = {}
     Events.build_menu_closed.emit()
     menu_closed.emit()
 
@@ -274,22 +272,5 @@ func _clamp_center() -> void:
     center.x = clamp(center.x, margin_x, rect.size.x - margin_x)
     center.y = clamp(center.y, margin_y, rect.size.y - margin_y)
 
-func set_base_cost(cost: Dictionary) -> void:
-    base_cost = cost.duplicate(true)
-
 func show_unaffordable_feedback(index: int) -> void:
     _show_unaffordable_feedback(index)
-
-func _combine_costs(a: Dictionary, b: Dictionary) -> Dictionary:
-    var combined: Dictionary = {}
-    for key in a.keys():
-        var resource: StringName = key if typeof(key) == TYPE_STRING_NAME else StringName(String(key))
-        var amount: float = float(a[key])
-        combined[resource] = float(combined.get(resource, 0.0)) + amount
-    for key in b.keys():
-        var resource_b: StringName = key if typeof(key) == TYPE_STRING_NAME else StringName(String(key))
-        var amount_b: float = float(b[key])
-        combined[resource_b] = float(combined.get(resource_b, 0.0)) + amount_b
-    for key in combined.keys():
-        combined[key] = int(round(float(combined[key])))
-    return combined

--- a/scripts/ui/QueenSelect.gd
+++ b/scripts/ui/QueenSelect.gd
@@ -18,7 +18,7 @@ var _closed_emitted: bool = false
 @onready var cards_box: HBoxContainer = $HBoxContainer
 
 func _ready() -> void:
-    mouse_filter = Control.MOUSE_FILTER_STOP
+    mouse_filter = Control.MOUSE_FILTER_IGNORE
     focus_mode = Control.FOCUS_ALL
     set_process_unhandled_input(true)
     _populate_cards()
@@ -66,6 +66,7 @@ func _unhandled_input(event: InputEvent) -> void:
         _confirm()
         _accept()
     elif event.is_action_pressed("cancel"):
+        _cancel_selection()
         _accept()
 
 func _accept() -> void:
@@ -142,6 +143,17 @@ func _confirm() -> void:
     GameState.apply_queen_effects(effects)
     _place_queen_in_center()
     queen_confirmed.emit(GameState.queen_id)
+    hide()
+    _closed_emitted = true
+    selection_closed.emit()
+    var tree := get_tree()
+    if tree:
+        tree.paused = false
+    queue_free()
+
+func _cancel_selection() -> void:
+    if _closed_emitted:
+        return
     hide()
     _closed_emitted = true
     selection_closed.emit()


### PR DESCRIPTION
## Summary
- remove mouse-dependent build interactions in the hive test harness and align highlights with keyboard selection
- bring radial ritual, queen selection, and offers panels onto consistent controller navigation that respects confirm/cancel shortcuts
- introduce a CostPolicy helper, update build logic to rely on JSON costs, and eliminate duplicated base cost handling in menus and config assets

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d464c4afa08322a16b394583bce81c