### PR TITLE
Fix ConfigDB autoload conflict

### DIFF
--- a/scripts/autoload/ConfigDB.gd
+++ b/scripts/autoload/ConfigDB.gd
@@ -8,7 +8,6 @@
 ## ConfigDB
 ## Central repository of configuration data loaded from data/configs.
 extends Node
-class_name ConfigDB
 
 const BUILD_ORDER: Array[StringName] = [
     StringName("Brood"),


### PR DESCRIPTION
## Summary
- remove the ConfigDB class_name declaration to prevent it from shadowing the autoload singleton

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5028e57d08322990b6ebb45f9f7a5