### PR TITLE
Remove redundant class_name declarations from autoload systems

### DIFF
--- a/scripts/systems/AbilitySystem.gd
+++ b/scripts/systems/AbilitySystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name AbilitySystem
 
 var _list: Array[Dictionary] = []
 

--- a/scripts/systems/CandleHallSystem.gd
+++ b/scripts/systems/CandleHallSystem.gd
@@ -8,7 +8,6 @@
 ## CandleHallSystem
 ## Handles starting rituals, tracking progress, and emitting ability rewards.
 extends Node
-class_name CandleHallSystem
 
 var _active: Dictionary = {}
 var _unlocked: bool = false

--- a/scripts/systems/ContractController.gd
+++ b/scripts/systems/ContractController.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name ContractController
 
 var _contracts: Dictionary = {}
 

--- a/scripts/systems/HarvestController.gd
+++ b/scripts/systems/HarvestController.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name HarvestController
 
 var _jobs: Dictionary = {}
 

--- a/scripts/systems/OfferSystem.gd
+++ b/scripts/systems/OfferSystem.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name OfferSystem
 
 var visible_harvests: Array[Dictionary] = []
 var visible_contracts: Array[Dictionary] = []

--- a/scripts/systems/ThreatSystem.gd
+++ b/scripts/systems/ThreatSystem.gd
@@ -8,7 +8,6 @@
 ## ThreatSystem
 ## Manages the threat lifecycle, including periodic warnings and boss encounters.
 extends Node
-class_name ThreatSystem
 
 var _rng := RandomNumberGenerator.new()
 var _tick_timer: Timer


### PR DESCRIPTION
## Summary
- remove duplicate class_name registrations from the Threat, Ability, CandleHall, Contract, Harvest, and Offer system autoload scripts to silence editor warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d50382479c83229e14bbc1bb04410e