### PR TITLE
Remove invalid EOF markers from UI assets

### DIFF
--- a/scenes/UI/AbilitiesPanel.tscn
+++ b/scenes/UI/AbilitiesPanel.tscn
@@ -118,4 +118,3 @@ custom_constants/separation = 12
 layout_mode = 2
 text = "L / Start = Close    Z = Cancel"
 vertical_alignment = 1
-*** End EOF

--- a/scenes/UI/AbilityRow.tscn
+++ b/scenes/UI/AbilityRow.tscn
@@ -42,4 +42,3 @@ vertical_alignment = 1
 custom_minimum_size = Vector2(120, 48)
 text = "Activate"
 focus_mode = 2
-*** End EOF

--- a/scenes/UI/RadialCandleHall.tscn
+++ b/scenes/UI/RadialCandleHall.tscn
@@ -37,4 +37,3 @@ size_flags_horizontal = 3
 horizontal_alignment = 1
 vertical_alignment = 1
 text = ""
-*** End EOF

--- a/scripts/systems/AbilitySystem.gd
+++ b/scripts/systems/AbilitySystem.gd
@@ -191,4 +191,3 @@ func _apply_effect(effect: Variant) -> bool:
             return HarvestController.apply_boost(effect)
         _:
             return false
-*** End EOF

--- a/scripts/ui/AbilityRow.gd
+++ b/scripts/ui/AbilityRow.gd
@@ -83,4 +83,3 @@ func _apply_style() -> void:
     style.set_border_width_all(1)
     style.set_corner_radius_all(12)
     add_theme_stylebox_override("panel", style)
-*** End EOF


### PR DESCRIPTION
## Summary
- remove stray `*** End EOF` markers from ability system script and UI scenes
- ensure scripts and scenes end cleanly so Godot no longer reports "Unexpected **" syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d504f0d2e88322bb661be62f49c933