### PR TITLE
Fix CandleHall ritual cleanup entry usage

### DIFF
--- a/scripts/systems/CandleHallSystem.gd
+++ b/scripts/systems/CandleHallSystem.gd
@@ -138,9 +138,9 @@ func _on_cell_converted(cell_id: int, new_type: StringName) -> void:
     else:
         if _active.has(cell_id):
             var entry: Dictionary = _active[cell_id]
-        var timer: SceneTreeTimer = entry.get("timer", null)
-        if timer:
-            timer.stop()
+            var timer: SceneTreeTimer = entry.get("timer", null)
+            if timer:
+                timer.stop()
             _active.erase(cell_id)
 
 func _ensure_unlocked() -> void:


### PR DESCRIPTION
## Summary
- ensure CandleHallSystem only accesses ritual entries when they exist during cell conversion cleanup
- stop any active ritual timer before removing it from the active set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b835970083229bc250e8f5a7da39