### PR TITLE
Fix candle ritual errors and clean up warnings

### DIFF
--- a/scripts/HexGridTest.gd
+++ b/scripts/HexGridTest.gd
@@ -9,8 +9,8 @@
 ## Drives the sandbox scene used for development testing of hive features.
 extends Node2D
 
-const HiveSystem := preload("res://scripts/systems/HiveSystem.gd")
-const MergeSystem := preload("res://scripts/systems/MergeSystem.gd")
+const _HiveSystemScript := preload("res://scripts/systems/HiveSystem.gd")
+const _MergeSystemScript := preload("res://scripts/systems/MergeSystem.gd")
 const FloatingTextScene := preload("res://scenes/FX/FloatingText.tscn")
 const HAMMER_TEXTURE := preload("res://art/icons/hammer.svg")
 const QueenSelectScene := preload("res://scenes/UI/QueenSelect.tscn")
@@ -204,7 +204,7 @@ func _add_available_neighbors(cell_id: int) -> void:
     else:
         queue_redraw()
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
     if _build_manager == null:
         return
     var has_building := false
@@ -487,14 +487,14 @@ func _on_production_tick(cell_id: int, resource_id: StringName, amount: int) -> 
 func _on_harvest_tick(_id: StringName, _time_left: float, partials: Dictionary) -> void:
     if typeof(partials) != TYPE_DICTIONARY or partials.is_empty():
         return
-    var position: Vector2 = _find_gathering_hut_position()
+    var hut_position: Vector2 = _find_gathering_hut_position()
     for key in partials.keys():
         var amount: int = int(partials.get(key, 0))
         if amount <= 0:
             continue
         var resource_id: StringName = StringName(String(key))
         var short_name: String = ConfigDB.get_resource_short_name(resource_id)
-        _spawn_floating_text(position, "+%d %s" % [amount, short_name])
+        _spawn_floating_text(hut_position, "+%d %s" % [amount, short_name])
 
 func _on_queen_fed(tier: StringName) -> void:
     if _queen_cell_id == -1:
@@ -564,21 +564,21 @@ func _ensure_queen_tile_state() -> void:
         return
     HiveSystem.set_cell_type(_queen_cell_id, SEAT_TYPE)
 
-func _spawn_floating_text(position: Vector2, text: String) -> void:
+func _spawn_floating_text(world_position: Vector2, text: String) -> void:
     var ft: Node = FloatingTextScene.instantiate()
     if ft == null:
         return
     if ft is Label:
         var label_ft: Label = ft
         add_child(label_ft)
-        label_ft.global_position = position
+        label_ft.global_position = world_position
         if label_ft.has_method("setup"):
             label_ft.setup(text)
         else:
             label_ft.text = text
     else:
         add_child(ft)
-        ft.global_position = position
+        ft.global_position = world_position
         if ft.has_method("setup"):
             ft.setup(text)
 

--- a/scripts/ui/ActiveJobsHud.gd
+++ b/scripts/ui/ActiveJobsHud.gd
@@ -245,8 +245,8 @@ func _create_progress_row(resource_id: StringName, total: int) -> Dictionary:
 
 func _format_time_left(seconds: float) -> String:
     var total: int = int(round(seconds))
-    var minutes: int = total / 60
-    var secs: int = total % 60
+    var minutes: int = int(total / 60.0)
+    var secs: int = total - minutes * 60
     return "%02d:%02d" % [minutes, secs]
 
 func _update_visibility() -> void:

--- a/scripts/ui/BroodInsertRadialMenu.gd
+++ b/scripts/ui/BroodInsertRadialMenu.gd
@@ -47,13 +47,13 @@ class RadialOptionControl extends Control:
     var disabled_alpha: float = 0.5
     var _flash_tween: Tween = null
 
-    func setup(label: StringName, info: String, size: Vector2, is_affordable: bool) -> void:
+    func setup(label: StringName, info: String, icon_dimensions: Vector2, is_affordable: bool) -> void:
         label_text = String(label)
         info_text = info
-        icon_size = size
+        icon_size = icon_dimensions
         affordable = is_affordable
         mouse_filter = Control.MOUSE_FILTER_IGNORE
-        custom_minimum_size = Vector2(size.x, size.y + 36)
+        custom_minimum_size = Vector2(icon_dimensions.x, icon_dimensions.y + 36)
         size = custom_minimum_size
         queue_redraw()
 

--- a/scripts/ui/RadialCandleHall.gd
+++ b/scripts/ui/RadialCandleHall.gd
@@ -93,7 +93,10 @@ func _refresh_state() -> void:
     if _cell_id < 0:
         return
     var cfg: Dictionary = ConfigDB.abilities_ritual_cfg()
-    var comb_cost: int = int(round(float(cfg.get("comb_cost", 0))))
+    var comb_value: Variant = cfg.get("comb_cost", 0)
+    var comb_cost: int = 0
+    if typeof(comb_value) == TYPE_FLOAT or typeof(comb_value) == TYPE_INT:
+        comb_cost = max(int(round(float(comb_value))), 0)
     if comb_cost > 0:
         start_button.text = "Start Ritual (-%d Comb)" % comb_cost
     else:
@@ -129,27 +132,27 @@ func _format_time_left() -> String:
     return "In progress (%.0fs)" % ceil(remaining)
 
 func _position_option_layer(center: Vector2) -> void:
-    var size: Vector2 = option_layer.size
-    if size == Vector2.ZERO:
-        size = option_layer.get_combined_minimum_size()
-        if size == Vector2.ZERO:
-            size = Vector2(200, 160)
-    option_layer.size = size
-    option_layer.position = center - size * 0.5
+    var layer_size: Vector2 = option_layer.size
+    if layer_size == Vector2.ZERO:
+        layer_size = option_layer.get_combined_minimum_size()
+        if layer_size == Vector2.ZERO:
+            layer_size = Vector2(200, 160)
+    option_layer.size = layer_size
+    option_layer.position = center - layer_size * 0.5
     _clamp_option_layer()
 
 func _clamp_option_layer() -> void:
     var rect: Rect2i = get_viewport_rect()
     var pos: Vector2 = option_layer.position
-    var size: Vector2 = option_layer.size
-    if size == Vector2.ZERO:
-        size = option_layer.get_combined_minimum_size()
+    var layer_size: Vector2 = option_layer.size
+    if layer_size == Vector2.ZERO:
+        layer_size = option_layer.get_combined_minimum_size()
     var min_x: float = padding.x
-    var max_x: float = rect.size.x - padding.x - size.x
+    var max_x: float = rect.size.x - padding.x - layer_size.x
     if max_x < min_x:
         max_x = min_x
     var min_y: float = padding.y
-    var max_y: float = rect.size.y - padding.y - size.y
+    var max_y: float = rect.size.y - padding.y - layer_size.y
     if max_y < min_y:
         max_y = min_y
     option_layer.position = Vector2(clamp(pos.x, min_x, max_x), clamp(pos.y, min_y, max_y))

--- a/scripts/ui/ThreatBanner.gd
+++ b/scripts/ui/ThreatBanner.gd
@@ -211,8 +211,8 @@ func _update_timer_display(seconds: float) -> void:
     progress_bar.value = seconds
     timer_value.text = _format_time(seconds)
 
-func _set_result(text: String, color: Color, show: bool) -> void:
-    result_label.visible = show and not text.is_empty()
+func _set_result(text: String, color: Color, should_show: bool) -> void:
+    result_label.visible = should_show and not text.is_empty()
     result_label.text = text
     result_label.modulate = color
 
@@ -231,6 +231,6 @@ func _hide_banner() -> void:
 
 func _format_time(seconds: float) -> String:
     var total: int = int(ceil(max(seconds, 0.0)))
-    var minutes: int = total / 60
-    var rem: int = total % 60
+    var minutes: int = int(total / 60.0)
+    var rem: int = total - minutes * 60
     return "%02d:%02d" % [minutes, rem]

--- a/scripts/ui/ThreatResolvePanel.gd
+++ b/scripts/ui/ThreatResolvePanel.gd
@@ -67,7 +67,7 @@ func _configure_slide_animations() -> void:
     else:
         push_warning("ThreatResolvePanel is missing 'slide_down' animation; falling back to instant hide")
 
-func _on_resolved(id: StringName, success: bool, power: int, defense: int) -> void:
+func _on_resolved(_id: StringName, success: bool, power: int, defense: int) -> void:
     _sequence_token += 1
     _stop_next_countdown()
     _fill_result(success, power, defense)
@@ -147,8 +147,9 @@ func _update_next_time() -> void:
         return
     var now: float = Time.get_unix_time_from_system()
     var left: float = maxf(0.0, _next_end_time - now)
-    var minutes := int(left) / 60
-    var seconds := int(left) % 60
+    var total: int = int(floor(left))
+    var minutes: int = int(total / 60.0)
+    var seconds: int = total - minutes * 60
     next_time.text = " in %02d:%02d" % [minutes, seconds]
     if left <= 0.0:
         _next_end_time = 0.0
@@ -185,8 +186,8 @@ func _hide_panel() -> void:
     _stop_next_countdown()
     _clear_next_box()
 
-func _on_animation_finished(name: StringName) -> void:
-    if name == StringName("slide_down"):
+func _on_animation_finished(anim_name: StringName) -> void:
+    if anim_name == StringName("slide_down"):
         _hide_panel()
 
 func _notification(what: int) -> void:


### PR DESCRIPTION
## Summary
- harden the candle hall ritual UI to safely parse ritual costs and avoid shadowed variables
- resolve various Godot warnings by renaming shadowed parameters and replacing implicit integer division
- keep HexGrid test helpers from clashing with global class names while improving naming clarity

## Testing
- `godot --headless --editor --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bb087768832295ca871be02e35ad