### PR TITLE
Handle expired SceneTreeTimers without using is_stopped

### DIFF
--- a/scripts/systems/CandleHallSystem.gd
+++ b/scripts/systems/CandleHallSystem.gd
@@ -77,9 +77,10 @@ func is_ritual_active(cell_id: int) -> bool:
         _active.erase(cell_id)
         return false
     var timer: SceneTreeTimer = entry.get("timer", null)
-    if timer and timer.is_stopped():
-        _active.erase(cell_id)
-        return false
+    if timer:
+        if not is_instance_valid(timer) or timer.time_left <= 0.0:
+            _active.erase(cell_id)
+            return false
     var ends_value: Variant = entry.get("ends_at", 0.0)
     var ends_at: float = 0.0
     if typeof(ends_value) == TYPE_FLOAT or typeof(ends_value) == TYPE_INT:


### PR DESCRIPTION
## Summary
- replace the `SceneTreeTimer.is_stopped()` guard with a validity and `time_left` check so expired timers are recognized without calling a missing method

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5bdab02a8832295559312f47b889c