### PR TITLE
Add Royal Jelly inventory entry to items config

### DIFF
--- a/assets/icons/royal_jelly.svg
+++ b/assets/icons/royal_jelly.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="jar" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8e27b"/>
+      <stop offset="100%" stop-color="#e0a21e"/>
+    </linearGradient>
+    <linearGradient id="lid" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7f5a1f"/>
+      <stop offset="100%" stop-color="#5b3c11"/>
+    </linearGradient>
+  </defs>
+  <rect x="18" y="10" width="28" height="8" rx="3" fill="url(#lid)"/>
+  <path d="M16 16h32v26c0 9.941-8.059 18-18 18s-18-8.059-18-18V16z" fill="url(#jar)" stroke="#c27a00" stroke-width="2"/>
+  <path d="M20 24c3 4 8 6 12 6s9-2 12-6" stroke="#fdf6c6" stroke-width="3" stroke-linecap="round" fill="none" opacity="0.6"/>
+  <circle cx="24" cy="36" r="4" fill="#fff2b1" opacity="0.7"/>
+</svg>

--- a/data/configs/items.json
+++ b/data/configs/items.json
@@ -1,9 +1,10 @@
 {
   "items": [
+    { "id": "RoyalJelly", "name": "Royal Jelly", "icon": "res://assets/icons/royal_jelly.svg" },
     { "id": "EggCommon", "name": "Common Egg", "icon": "res://assets/icons/egg_common.svg" },
     { "id": "EggUnique", "name": "Unique Egg", "icon": "res://assets/icons/egg_unique.svg" },
     { "id": "EggRare", "name": "Rare Egg", "icon": "res://assets/icons/egg_rare.svg" },
     { "id": "ThistleFlower", "name": "Thistle Flower", "icon": "res://assets/icons/thistle.svg" }
   ],
-  "order": ["EggCommon", "EggUnique", "EggRare", "ThistleFlower"]
+  "order": ["RoyalJelly", "EggCommon", "EggUnique", "EggRare", "ThistleFlower"]
 }

--- a/docs/Design_RevB_alignment_tasks.md
+++ b/docs/Design_RevB_alignment_tasks.md
@@ -6,7 +6,7 @@ This checklist captures gaps between the RevB design description and the current
 
 - [x] Update the design doc (or trim the configs) so that the resource list matches reality. RevB only lists Honey/Comb/Pollen/NectarCommon, but `resources.json` also exposes NectarSweet, NectarRich, and six Petal resources. Decide whether the design should embrace these extra resource types or whether the data should be reduced. (Design doc §"Resources & Items" lines 24–25 vs. `data/configs/resources.json`.) — **Resolved:** Design now explicitly lists the three Nectar grades and six Petal colors alongside the base resources.
 - [ ] Reconcile the inventory model. RevB states that only Royal Jelly is an inventory item and eggs are hidden, yet `items.json` exposes three egg items plus Thistle Flowers, and `start_values.json` seeds EggCommon inventory. Align the doc and data by either documenting the existing items or changing the configs. (Design doc lines 24–25 vs. `data/configs/items.json` and `data/configs/start_values.json`.)
-- [ ] Clarify how Royal Jelly is represented. The design references RJ as an item but there is no explicit item entry in `items.json`. Confirm whether RJ should be added to the data or the doc should instead call it out as a derived value.
+- [x] Clarify how Royal Jelly is represented. The design references RJ as an item but there is no explicit item entry in `items.json`. Confirm whether RJ should be added to the data or the doc should instead call it out as a derived value. — **Resolved:** `items.json` now defines a Royal Jelly inventory item and icon to match the design description.
 
 ## Brood & Egg Flow
 


### PR DESCRIPTION
## Summary
- define a Royal Jelly inventory entry in `data/configs/items.json` so the data matches the design doc
- add a Royal Jelly jar icon asset referenced by the new item configuration
- mark the RevB alignment checklist item for Royal Jelly representation as resolved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc451f4e48322837091859a896cac